### PR TITLE
[11.0] [ADD] Add module currency_rate_update_RO_BNR to v 11.

### DIFF
--- a/currency_rate_update_RO_BNR/README.rst
+++ b/currency_rate_update_RO_BNR/README.rst
@@ -1,0 +1,87 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==========================
+Currency Rate Update - BNR
+==========================
+
+Download exchange rates automatically from  National Bank of Romania (Banca Nationala a Romaniei) service
+
+Installation
+============
+
+To install this module, you need to:
+
+* clone the branch 11.0 of the repository https://github.com/OCA/l10n-romania
+* add the path to this repository in your configuration (addons-path)
+* update the module list
+* search for "Currency Rate Update - BNR" in your addons
+* install the module
+
+The module depends on currency_rate_update module available on https://github.com/OCA/currency
+
+Usage
+=====
+
+The module supports multi-company currency in two ways:
+
+* when currencies are shared, you can set currency update only on one
+  company
+* when currencies are separated, you can set currency on every company
+  separately
+
+A function field lets you know your currency configuration.
+
+If in multi-company mode, the base currency will be the first company's
+currency found in database.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/l10n-romania/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Nicolas Bessi <nicolas.bessi@camptocamp.com>
+* Jean-Baptiste Aubort <jean-baptiste.aubort@camptocamp.com>
+* Joël Grand-Guillaume <joel.grandguillaume@camptocamp.com>
+* Grzegorz Grzelak <grzegorz.grzelak@openglobe.pl> (ECB, NBP)
+* Vincent Renaville <vincent.renaville@camptocamp.com>
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Lorenzo Battistini <lorenzo.battistini@agilebg.com> (Port to V7)
+* Agustin Cruz <openpyme.mx> (BdM)
+* Jacque-Etienne Baudoux <je@bcim.be>
+* Juan Jose Scarafia <jjscarafia@paintballrosario.com.ar>
+* Mathieu Benoi <mathben963@gmail.com>
+* Fekete Mihai <feketemihai@gmail.com> (Port to V8)
+* Dorin Hongu <dhongu@gmail.com> (BNR)
+* Paul McDermott
+* Alexis de Lattre <alexis@via.ecp.fr>
+* Miku Laitinen
+* Assem Bayahi
+* Daniel Dico <ddico@oerp.ca> (BOC)
+* Dmytro Katyukha <firemage.dima@gmail.com>
+* Jesús Ventosinos Mayor <jesus@comunitea.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/currency_rate_update_RO_BNR/__init__.py
+++ b/currency_rate_update_RO_BNR/__init__.py
@@ -1,0 +1,1 @@
+from . import services

--- a/currency_rate_update_RO_BNR/__manifest__.py
+++ b/currency_rate_update_RO_BNR/__manifest__.py
@@ -1,0 +1,17 @@
+# © 2017 Comunitea
+# © 2018 Forest and Biomass Romania
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Currency Rate Update - BNR',
+    'summary': 'Currency Rate Update National Bank of Romania service',
+    'version': '11.0.1.0.0',
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/l10n-romania",
+    "license": "AGPL-3",
+    "category": "Financial Management/Configuration",
+    "depends": [
+        "base",
+        "currency_rate_update"
+    ],
+    'installable': True
+}

--- a/currency_rate_update_RO_BNR/services/__init__.py
+++ b/currency_rate_update_RO_BNR/services/__init__.py
@@ -1,0 +1,1 @@
+from . import update_service_RO_BNR

--- a/currency_rate_update_RO_BNR/services/update_service_RO_BNR.py
+++ b/currency_rate_update_RO_BNR/services/update_service_RO_BNR.py
@@ -1,0 +1,89 @@
+# © 2009 Camptocamp
+# © 2014 Dorin Hongu
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime, timedelta
+import logging
+
+from odoo.addons.currency_rate_update.services.currency_getter_interface \
+    import CurrencyGetterInterface
+
+_logger = logging.getLogger(__name__)
+
+
+class ROBNRGetter(CurrencyGetterInterface):
+    """Implementation of Currency_getter_factory interface for BNR service"""
+
+    code = 'RO_BNR'
+    name = 'National Bank of Romania'
+    supported_currency_array = [
+        "AED", "AUD", "BGN", "BRL", "CAD", "CHF", "CNY", "CZK", "DKK", "EGP",
+        "EUR", "GBP", "HUF", "INR", "JPY", "KRW", "MDL", "MXN", "NOK", "NZD",
+        "PLN", "RON", "RSD", "RUB", "SEK", "TRY", "UAH", "USD", "XAU", "XDR",
+        "ZAR"]
+
+    def rate_retrieve(self, dom, ns, curr):
+        """ Parse a dom node to retrieve-
+        currencies data"""
+        res = {}
+        xpath_rate_currency = "/def:DataSet/def:Body/def:Cube/def:Rate" + \
+                              "[@currency='%s']/text()" % (curr.upper())
+        xpath_rate_ref = "/def:DataSet/def:Body/def:Cube/def:Rate" + \
+                         "[@currency='%s']/@multiplier" % (curr.upper())
+        res['rate_currency'] = float(dom.xpath(xpath_rate_currency,
+                                               namespaces=ns)[0])
+        try:
+            res['rate_ref'] = float(dom.xpath(xpath_rate_ref,
+                                              namespaces=ns)[0])
+        except:
+            res['rate_ref'] = 1
+        return res
+
+    def get_updated_currency(self, currency_array, main_currency,
+                             max_delta_days):
+        """implementation of abstract method of Curreny_getter_interface"""
+        url = 'http://www.bnr.ro/nbrfxrates.xml'
+        # we do not want to update the main currency
+        if main_currency in currency_array:
+            currency_array.remove(main_currency)
+        # Move to new XML lib cf Launchpad bug #645263
+        from lxml import etree
+        _logger.debug("BNR currency rate service : connecting...")
+        rawfile = self.get_url(url)
+        dom = etree.fromstring(rawfile)
+        adminch_ns = {'def': 'http://www.bnr.ro/xsd'}
+        rate_date = dom.xpath('/def:DataSet/def:Body/def:Cube/@date',
+                              namespaces=adminch_ns)[0]
+        rate_date_datetime = datetime.strptime(rate_date, '%Y-%m-%d') + \
+            timedelta(days=1)
+        self.check_rate_date(rate_date_datetime, max_delta_days)
+        # we dynamically update supported currencies
+        self.supported_currency_array = dom.xpath(
+            "/def:DataSet/def:Body/" + "def:Cube/def:Rate/@currency",
+            namespaces=adminch_ns)
+        self.supported_currency_array = [
+            x.upper() for x in self.supported_currency_array]
+        self.supported_currency_array.append('RON')
+
+        self.validate_cur(main_currency)
+        if main_currency != 'RON':
+            main_curr_data = self.rate_retrieve(dom, adminch_ns, main_currency)
+            # 1 MAIN_CURRENCY = main_rate RON
+            main_rate = main_curr_data['rate_currency'] / \
+                main_curr_data['rate_ref']
+        for curr in currency_array:
+            self.validate_cur(curr)
+            if curr == 'RON':
+                rate = main_rate
+            else:
+                curr_data = self.rate_retrieve(dom, adminch_ns, curr)
+                # 1 MAIN_CURRENCY = rate CURR
+                if main_currency == 'RON':
+                    rate = curr_data['rate_ref'] / curr_data['rate_currency']
+                else:
+                    rate = main_rate * curr_data['rate_ref'] / \
+                        curr_data['rate_currency']
+            self.updated_currency[curr] = rate
+            _logger.debug("BNR Rate retrieved : 1 " + main_currency + ' = ' +
+                          str(rate) + ' ' + curr)
+        return self.updated_currency, self.log_info

--- a/currency_rate_update_RO_BNR/tests/__init__.py
+++ b/currency_rate_update_RO_BNR/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_currency_rate_update_ro_bnr

--- a/currency_rate_update_RO_BNR/tests/test_currency_rate_update_ro_bnr.py
+++ b/currency_rate_update_RO_BNR/tests/test_currency_rate_update_ro_bnr.py
@@ -1,0 +1,48 @@
+# © 2017 Comunitea
+# © 2018 Forest and Biomass Romania
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import common
+
+
+class TestCurrencyRateUpdateRoBnr(common.SavepointCase):
+
+    def setUp(self):
+        super(TestCurrencyRateUpdateRoBnr, self).setUp()
+        self.usd = self.env.ref('base.USD')
+        self.euro = self.env.ref('base.EUR')
+        self.ron = self.env.ref('base.RON')
+        self.ron.write({'active': True})
+        currency_rates = self.env['res.currency.rate'].search(
+            [('currency_id', '=', self.usd.id)])
+        currency_rates.unlink()
+        currency_rates = self.env['res.currency.rate'].search(
+            [('currency_id', '=', self.euro.id)])
+        currency_rates.unlink()
+        currency_rates = self.env['res.currency.rate'].search(
+            [('currency_id', '=', self.ron.id)])
+        currency_rates.unlink()
+        self.main_currency = self.env.user.company_id.currency_id
+        self.update_service = self.env['currency.rate.update.service'].create({
+            'service': 'RO_BNR',
+            'currency_to_update': [(6, 0,
+                                    [self.euro.id, self.ron.id, self.usd.id])]
+        })
+
+    def test_currency_rate_update_USD_RON(self):
+        curr = self.ron
+        if self.main_currency.name == 'RON':
+            curr = self.usd
+        self.update_service.refresh_currency()
+        currency_rates = self.env['res.currency.rate'].search(
+            [('currency_id', '=', curr.id)])
+        self.assertTrue(currency_rates)
+
+    def test_currency_rate_update_USD_EUR(self):
+        curr = self.euro
+        if self.main_currency.name == 'EUR':
+            curr = self.ron
+        self.update_service.refresh_currency()
+        currency_rates = self.env['res.currency.rate'].search(
+            [('currency_id', '=', curr.id)])
+        self.assertTrue(currency_rates)

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,4 +1,6 @@
+account-financial-reporting
 bank-statement-import
+currency
 hr
 reporting-engine
 server-ux


### PR DESCRIPTION
Module is extracted from https://github.com/OCA/account-financial-tools/pull/579.