### PR TITLE
[13.0][IMP] reception return to use origin valuation unit cost [WIP]

### DIFF
--- a/currency_rate_update_RO_BNR/static/description/index.html
+++ b/currency_rate_update_RO_BNR/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Currency Rate Update - BNR</title>
 <style type="text/css">
 

--- a/difff.txt
+++ b/difff.txt
@@ -1,0 +1,16 @@
+[1mdiff --git a/l10n_ro_stock_account/models/stock_move.py b/l10n_ro_stock_account/models/stock_move.py[m
+[1mindex 05919a4..bbea619 100644[m
+[1m--- a/l10n_ro_stock_account/models/stock_move.py[m
+[1m+++ b/l10n_ro_stock_account/models/stock_move.py[m
+[36m@@ -570,7 +570,10 @@[m [mclass StockMoveLine(models.Model):[m
+     @api.model[m
+     def _create_correction_svl(self, move, diff):[m
+         super(StockMoveLine, self)._create_correction_svl(move, diff)[m
+[31m-        if not self.company_id.romanian_accounting:[m
+[32m+[m[32m        company_id = self.company_id[m
+[32m+[m[32m        if not self.company_id and self._context.get('default_company_id'):[m
+[32m+[m[32m            company_id = self.env['res.company'].browse(self._context['default_company_id'])[m
+[32m+[m[32m        if not company_id.romanian_accounting:[m
+             return[m
+ [m
+         stock_valuation_layers = self.env["stock.valuation.layer"][m

--- a/l10n_ro_account_period_close/static/description/index.html
+++ b/l10n_ro_account_period_close/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Account Period Closing</title>
 <style type="text/css">
 

--- a/l10n_ro_account_report_invoice/static/description/index.html
+++ b/l10n_ro_account_report_invoice/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Invoice Report</title>
 <style type="text/css">
 

--- a/l10n_ro_address_extended/static/description/index.html
+++ b/l10n_ro_address_extended/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Extended Addresses</title>
 <style type="text/css">
 

--- a/l10n_ro_city/static/description/index.html
+++ b/l10n_ro_city/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - City</title>
 <style type="text/css">
 

--- a/l10n_ro_config/static/description/index.html
+++ b/l10n_ro_config/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Localization Config</title>
 <style type="text/css">
 

--- a/l10n_ro_fiscal_validation/static/description/index.html
+++ b/l10n_ro_fiscal_validation/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Fiscal Validation</title>
 <style type="text/css">
 

--- a/l10n_ro_partner_create_by_vat/static/description/index.html
+++ b/l10n_ro_partner_create_by_vat/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Partner Create by VAT</title>
 <style type="text/css">
 

--- a/l10n_ro_partner_statement/static/description/index.html
+++ b/l10n_ro_partner_statement/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Partner Statement</title>
 <style type="text/css">
 

--- a/l10n_ro_partner_unique/static/description/index.html
+++ b/l10n_ro_partner_unique/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Partners Unique</title>
 <style type="text/css">
 

--- a/l10n_ro_siruta/static/description/index.html
+++ b/l10n_ro_siruta/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Siruta</title>
 <style type="text/css">
 

--- a/l10n_ro_stock/static/description/index.html
+++ b/l10n_ro_stock/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Stock</title>
 <style type="text/css">
 

--- a/l10n_ro_stock_account/__init__.py
+++ b/l10n_ro_stock_account/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -22,6 +22,7 @@
         "views/stock_location_view.xml",
         "views/stock_picking_view.xml",
         "views/stock_valuation_layer_views.xml",
+        "wizard/stock_picking_return_views.xml",
     ],
     "installable": True,
     "maintainers": ["dhongu", "feketemihai"],

--- a/l10n_ro_stock_account/models/product.py
+++ b/l10n_ro_stock_account/models/product.py
@@ -188,7 +188,6 @@ class ProductProduct(models.Model):
             .sudo()
             .browse(self._context["origin_return_candidates"])
         )
-
         qty_to_take_on_candidates = quantity
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates

--- a/l10n_ro_stock_account/models/product.py
+++ b/l10n_ro_stock_account/models/product.py
@@ -7,6 +7,7 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_is_zero
 
 _logger = logging.getLogger(__name__)
 
@@ -171,3 +172,83 @@ class ProductTemplate(models.Model):
             accounts["stock_input"] = property_stock_usage_giving_account_id
             accounts["stock_valuation"] = property_stock_usage_giving_account_id
         return accounts
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _run_fifo(self, quantity, company):
+        self.ensure_one()
+
+        if not self._context.get("origin_return_candidates"):
+            return super(ProductProduct, self)._run_fifo(quantity, company)
+
+        candidates = (
+            self.env["stock.valuation.layer"]
+            .sudo()
+            .browse(self._context["origin_return_candidates"])
+        )
+
+        qty_to_take_on_candidates = quantity
+        new_standard_price = 0
+        tmp_value = 0  # to accumulate the value taken on the candidates
+        for candidate in candidates:
+            qty_taken_on_candidate = min(
+                qty_to_take_on_candidates, candidate.remaining_qty
+            )
+
+            candidate_unit_cost = candidate.remaining_value / candidate.remaining_qty
+            new_standard_price = candidate_unit_cost
+            value_taken_on_candidate = qty_taken_on_candidate * candidate_unit_cost
+            value_taken_on_candidate = candidate.currency_id.round(
+                value_taken_on_candidate
+            )
+            new_remaining_value = candidate.remaining_value - value_taken_on_candidate
+
+            candidate_vals = {
+                "remaining_qty": candidate.remaining_qty - qty_taken_on_candidate,
+                "remaining_value": new_remaining_value,
+            }
+
+            candidate.write(candidate_vals)
+
+            qty_to_take_on_candidates -= qty_taken_on_candidate
+            tmp_value += value_taken_on_candidate
+            if float_is_zero(
+                qty_to_take_on_candidates, precision_rounding=self.uom_id.rounding
+            ):
+                break
+
+        # Update the standard price with the price of the last used candidate, if any.
+        if new_standard_price and self.cost_method == "fifo":
+            self.sudo().with_context(
+                force_company=company.id
+            ).standard_price = new_standard_price
+
+        # If there's still quantity to value but we're out of candidates, we fall in the
+        # negative stock use case. We chose to value the out move at the price of the
+        # last out and a correction entry will be made once `_fifo_vacuum` is called.
+        vals = {}
+        if float_is_zero(
+            qty_to_take_on_candidates, precision_rounding=self.uom_id.rounding
+        ):
+            vals = {
+                "value": -tmp_value,
+                "unit_cost": tmp_value / quantity,
+            }
+        else:
+            self = self.with_context(origin_return_candidates=None)
+            vals_rest = super(ProductProduct, self)._run_fifo(
+                qty_to_take_on_candidates, company
+            )
+            value = -(tmp_value + abs(vals_rest["value"]))
+            unit_cost = abs(value) / (quantity - abs(vals_rest.get("remaining_qty", 0)))
+            if "remaining_qty" in vals_rest:
+                vals.update(
+                    value=value,
+                    unit_cost=unit_cost,
+                    remaining_qty=vals_rest["remaining_qty"],
+                )
+            else:
+                vals.update(value=value, unit_cost=unit_cost)
+        return vals

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -83,6 +83,15 @@ class StockMove(models.Model):
 
     def _create_reception_return_svl(self, forced_quantity=None):
         move = self.with_context(standard=True, valued_type="reception_return")
+        if (
+            move.origin_returned_move_id
+            and move.origin_returned_move_id.sudo().stock_valuation_layer_ids
+        ):
+            move = move.with_context(
+                origin_return_candidates=move.origin_returned_move_id.sudo()
+                .stock_valuation_layer_ids.filtered(lambda sv: sv.remaining_qty > 0)
+                .ids
+            )
         return move._create_out_svl(forced_quantity)
 
     def _is_reception_notice(self):
@@ -111,6 +120,15 @@ class StockMove(models.Model):
 
     def _create_reception_notice_return_svl(self, forced_quantity=None):
         move = self.with_context(standard=True, valued_type="reception_notice_return")
+        if (
+            move.origin_returned_move_id
+            and move.origin_returned_move_id.sudo().stock_valuation_layer_ids
+        ):
+            move = move.with_context(
+                origin_return_candidates=move.origin_returned_move_id.sudo()
+                .stock_valuation_layer_ids.filtered(lambda sv: sv.remaining_qty > 0)
+                .ids
+            )
         return move._create_out_svl(forced_quantity)
 
     def _is_delivery(self):
@@ -579,7 +597,12 @@ class StockMoveLine(models.Model):
     @api.model
     def _create_correction_svl(self, move, diff):
         super(StockMoveLine, self)._create_correction_svl(move, diff)
-        if not self.company_id.romanian_accounting:
+        company_id = self.company_id
+        if not self.company_id and self._context.get("default_company_id"):
+            company_id = self.env["res.company"].browse(
+                self._context["default_company_id"]
+            )
+        if not company_id.romanian_accounting:
             return
 
         stock_valuation_layers = self.env["stock.valuation.layer"]

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - Stock Accounting</title>
 <style type="text/css">
 

--- a/l10n_ro_stock_account/tests/__init__.py
+++ b/l10n_ro_stock_account/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_sale
 from . import test_inventory
 
 from . import test_consum
+from . import test_reception_return_not_fifo

--- a/l10n_ro_stock_account/tests/test_reception_return_not_fifo.py
+++ b/l10n_ro_stock_account/tests/test_reception_return_not_fifo.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2020 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+# Generare note contabile la achizitie
+import logging
+
+from .common import TestStockCommon
+
+_logger = logging.getLogger(__name__)
+
+
+class TestStockPurchaseReturn(TestStockCommon):
+    def test_not_fifo_return(self):
+        po1 = self.create_po(notice=False)
+        self.create_invoice()
+        _logger.info("PO1: %s" % po1.amount_total)
+        _logger.info("Product1 price: %s" % self.product_1.standard_price)
+
+        stock_value_p1 = round(self.qty_po_p1 * self.price_p1, 2)
+        stock_value_p2 = round(self.qty_po_p2 * self.price_p2, 2)
+        self.check_stock_valuation(stock_value_p1, stock_value_p2)
+
+        self.price_p1 = 55.0
+        po2 = self.create_po(notice=False)
+        self.create_invoice()
+        _logger.info("PO2: %s" % po2.amount_total)
+        _logger.info("Product1 price: %s" % self.product_1.standard_price)
+
+        stock_value_final_p1 = stock_value_p1 + round(self.qty_po_p1 * self.price_p1, 2)
+        stock_value_final_p2 = stock_value_p2 + round(self.qty_po_p2 * self.price_p2, 2)
+        self.check_stock_valuation(stock_value_final_p1, stock_value_final_p2)
+
+        pick = po2.picking_ids
+        self.make_return(pick, 2)
+
+        stock_value_final_p1 = stock_value_final_p1 - round(2 * self.price_p1, 2)
+        self.check_stock_valuation(stock_value_final_p1, stock_value_final_p2)

--- a/l10n_ro_stock_account/tests/test_reception_return_not_fifo.py
+++ b/l10n_ro_stock_account/tests/test_reception_return_not_fifo.py
@@ -34,4 +34,5 @@ class TestStockPurchaseReturn(TestStockCommon):
         self.make_return(pick, 2)
 
         stock_value_final_p1 = stock_value_final_p1 - round(2 * self.price_p1, 2)
+        stock_value_final_p2 = stock_value_final_p2 - round(2 * self.price_p2, 2)
         self.check_stock_valuation(stock_value_final_p1, stock_value_final_p2)

--- a/l10n_ro_stock_account/wizard/__init__.py
+++ b/l10n_ro_stock_account/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking_return

--- a/l10n_ro_stock_account/wizard/stock_picking_return.py
+++ b/l10n_ro_stock_account/wizard/stock_picking_return.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2021 NextERP Romania
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models
+
+
+class StockReturnPickingLine(models.TransientModel):
+    _inherit = "stock.return.picking.line"
+
+    origin_ret_move_qty_check = fields.Boolean(compute="_compute_origin_ret_move_qty")
+    origin_ret_move_qty = fields.Float(compute="_compute_origin_ret_move_qty")
+
+    @api.depends("quantity")
+    def _compute_origin_ret_move_qty(self):
+        for line in self:
+            mv = line.move_id.sudo()
+            if mv.stock_valuation_layer_ids:
+                vls = mv.stock_valuation_layer_ids.filtered(
+                    lambda sv: sv.remaining_qty > 0
+                )
+                mv_rem_qty = sum(vls.mapped("remaining_qty"))
+                line.origin_ret_move_qty = mv_rem_qty
+                line.origin_ret_move_qty_check = mv_rem_qty >= line.quantity
+            else:
+                line.origin_ret_move_qty = line.quantity
+                line.origin_ret_move_qty_check = True

--- a/l10n_ro_stock_account/wizard/stock_picking_return_views.xml
+++ b/l10n_ro_stock_account/wizard/stock_picking_return_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_return_picking_form" model="ir.ui.view">
+        <field name="name">Return lines</field>
+        <field name="model">stock.return.picking</field>
+        <field name="inherit_id" ref="stock.view_stock_return_picking_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='product_return_moves']/tree/field[@name='quantity']"
+                position="after"
+            >
+                <field name="origin_ret_move_qty_check" invisible="1" />
+                <button
+                    readonly="True"
+                    width="2"
+                    style="color: red; position: relative; left: -6px;"
+                    string="Quantity more than existing. You will return different stock valuations."
+                    icon="fa-exclamation-triangle"
+                    attrs="{'invisible': [('origin_ret_move_qty_check', '=', True)]}"
+                >
+
+                </button>
+                <field
+                    name="origin_ret_move_qty"
+                    attrs="{'invisible': [('origin_ret_move_qty_check', '=', True)]}"
+                    string="Remaining Qty"
+                    style="color: red;"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ro_vat_on_payment/static/description/index.html
+++ b/l10n_ro_vat_on_payment/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Romania - VAT on Payment</title>
 <style type="text/css">
 


### PR DESCRIPTION
La retururi furnizori, rezervarea in valuation layer se ia FIFO, pentru ca creem "out" valuation layer, astfel nu rezerva exact din cantitatea intrata pe picking-ul initial. Metoda adauga un check in care putem vedea care mai este cantitatea disponibila de pe receptia  initiala. Daca vrem sa returnam mai mult sistemul va semnaliza print-o exclamatie acest lucru.