### PR TITLE
[FIX] the rounding of price_unit may result in wrong price_unit_val_dif

### DIFF
--- a/l10n_ro_stock_account/models/account_invoice.py
+++ b/l10n_ro_stock_account/models/account_invoice.py
@@ -242,7 +242,7 @@ class AccountMoveLine(models.Model):
             return 0.0
 
         valuation_price_unit = valuation_price_unit_total / valuation_total_qty
-        price_unit = line.balance / line.quantity
+        price_unit = abs(line.balance / line.quantity)
         price_unit_val_dif = price_unit - valuation_price_unit
         return price_unit_val_dif
 

--- a/l10n_ro_stock_account/models/account_invoice.py
+++ b/l10n_ro_stock_account/models/account_invoice.py
@@ -216,7 +216,6 @@ class AccountMoveLine(models.Model):
     def get_stock_valuation_difference(self):
         """ Se obtine diferenta dintre evaloarea stocului si valoarea din factura"""
         line = self
-        move = line.move_id
         # Retrieve stock valuation moves.
         if not line.purchase_line_id:
             return 0.0
@@ -243,26 +242,7 @@ class AccountMoveLine(models.Model):
             return 0.0
 
         valuation_price_unit = valuation_price_unit_total / valuation_total_qty
-        price_unit = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-        if line.tax_ids:
-            price_unit = line.tax_ids.compute_all(
-                price_unit,
-                currency=move.currency_id,
-                quantity=1.0,
-                is_refund=move.type == "in_refund",
-            )["total_excluded"]
-
-        price_unit = line.product_uom_id._compute_price(
-            price_unit, line.product_id.uom_id
-        )
-
-        price_unit = move.currency_id._convert(
-            price_unit,
-            move.company_currency_id,
-            move.company_id,
-            move.invoice_date,
-            round=False,
-        )
+        price_unit = line.balance / line.quantity
         price_unit_val_dif = price_unit - valuation_price_unit
         return price_unit_val_dif
 


### PR DESCRIPTION
Atunci cand cantitatile sunt de ordinul sutelor sau miilor in factura, pretul unitar in euro poate fi ceva de genul 0.035
daca rounding-ul pe currency EUR este 0.01, atunci price_unit va fi 0.4 (EUR) = 
prince_unit (RON) = 0.4 x 4.9123 = 1.96

insa la calculul de price unit pentru valuation-ul de receptie nu este nici o rotunjire
valuation_price_unit = valuation_price_unit_total / valuation_total_qty

daca cantitatea = 1000
=> valuation de Price Difference va avea o valoare mult mai mare decat ar trebui sa fie intre contabilitate si stoc.

