### PR TITLE
[15.0] dotfiles update needs manual intervention

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.3.2
+_commit: v1.3.3
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.0.2
+    rev: 3.0.3
     hooks:
       - id: setuptools-odoo-make-default
       - id: setuptools-odoo-get-requirements

--- a/.pre-commit-config.yaml.rej
+++ b/.pre-commit-config.yaml.rej
@@ -1,6 +1,0 @@
-diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
-@@ -107,3 +106,3 @@ repos:
-   - repo: https://github.com/acsone/setuptools-odoo
--    rev: 2.7.1
-+    rev: 3.0.2
-     hooks:

--- a/.pre-commit-config.yaml.rej
+++ b/.pre-commit-config.yaml.rej
@@ -1,0 +1,6 @@
+diff a/.pre-commit-config.yaml b/.pre-commit-config.yaml	(rejected hunks)
+@@ -107,3 +106,3 @@ repos:
+   - repo: https://github.com/acsone/setuptools-odoo
+-    rev: 2.7.1
++    rev: 3.0.2
+     hooks:


### PR DESCRIPTION
Dear maintainer,

After updating the dotfiles, `pre-commit run -a`
fails in a manner that cannot be resolved automatically.

Can you please have a look, fix and merge?

Thanks,
