### PR TITLE
Update res_currency_rate_provider_RO_BNR.py

### DIFF
--- a/currency_rate_update_RO_BNR/models/res_currency_rate_provider_RO_BNR.py
+++ b/currency_rate_update_RO_BNR/models/res_currency_rate_provider_RO_BNR.py
@@ -122,7 +122,7 @@ class ROBNRRatesHandler(xml.sax.ContentHandler):
         elif name == "Rate" and all([x in attrs for x in ["currency"]]):
             currency = attrs["currency"]
             self.currency = currency
-            self.multiplier = attrs.get("multiplier", 1)
+            self.multiplier = float(attrs.get("multiplier", 1))
             self.rate = 1
         self.tags.append(name)
 


### PR DESCRIPTION
atributul multiplier este vazut str nu float. Ex: <Rate currency="JPY" multiplier="100">3.4595</Rate> 