### PR TITLE
[14.0][FIX] schimbare Costing Method

### DIFF
--- a/l10n_ro_stock_account/models/product_product.py
+++ b/l10n_ro_stock_account/models/product_product.py
@@ -448,6 +448,7 @@ class ProductProduct(models.Model):
                 ]
 
             for vals in svsl_vals:
+                vals.pop("l10n_ro_tracking")
                 vals["description"] = description + vals.pop("rounding_adjustment", "")
                 vals["company_id"] = self.env.company.id
             empty_stock_svl_list.extend(svsl_vals)


### PR DESCRIPTION
eroare ca field-ul l10n_ro_tracking nu exista cand se creaza SVL out empty stock

Se reproduce schimband Costing Method de pe categorie in FIFO, apoi AVG, apoi iar FIFO