### PR TITLE
[15.0][FIX] eliminare l10n_ro_tracking inainte de creare SVL

### DIFF
--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -125,6 +125,7 @@ class StockValuationLayer(models.Model):
                     )
                     if svl:
                         values["l10n_ro_valued_type"] = svl.l10n_ro_valued_type
+            values.pop("l10n_ro_tracking", None)
         return super(StockValuationLayer, self).create(vals_list)
 
     def _l10n_ro_compute_invoice_line_id(self):


### PR DESCRIPTION
Pentru a nu ajunge in situatia in care se apeleaza metoda standard create SVL si sa existe in continuare l10n_ro_tracking in lista de valori.