### PR TITLE
[14.0][IMP] setare invoice_id si invoice_line_id pe SVL price difference

### DIFF
--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -111,12 +111,18 @@ class StockValuationLayer(models.Model):
                         # if aml.balance > 0 and svl.value > 0:
                         #     account = aml.account_id
                         #     break
-            if (
-                svl.l10n_ro_valued_type in ("reception", "reception_return")
-                and svl.l10n_ro_invoice_line_id
-            ):
-                account = svl.l10n_ro_invoice_line_id.account_id
+            if svl._l10n_ro_can_use_invoice_line_account(account):
+                if (
+                    svl.l10n_ro_valued_type in ("reception", "reception_return")
+                    and svl.l10n_ro_invoice_line_id
+                ):
+                    account = svl.l10n_ro_invoice_line_id.account_id
             svl.l10n_ro_account_id = account
+
+    # hook method for reception in progress
+    def _l10n_ro_can_use_invoice_line_account(self, account):
+        self.ensure_one()
+        return True
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_ro_stock_account_reception_in_progress/models/__init__.py
+++ b/l10n_ro_stock_account_reception_in_progress/models/__init__.py
@@ -4,3 +4,4 @@ from . import product
 from . import purchase_order
 from . import stock_move
 from . import stock_picking
+from . import stock_valuation_layer

--- a/l10n_ro_stock_account_reception_in_progress/models/stock_picking.py
+++ b/l10n_ro_stock_account_reception_in_progress/models/stock_picking.py
@@ -9,6 +9,25 @@ class StockPicking(models.Model):
     _name = "stock.picking"
     _inherit = ["stock.picking", "l10n.ro.mixin"]
 
+    def l10n_ro_set_valuations_invoice_line(self, invoices):
+        for invoice in invoices:
+            invoice_lines = invoice.invoice_line_ids.filtered(
+                lambda l: not l.display_type
+            )
+            for line in invoice_lines:
+                valuation_stock_moves = line._l10n_ro_get_valuation_stock_moves()
+                if valuation_stock_moves:
+                    svls = valuation_stock_moves.sudo().mapped(
+                        "stock_valuation_layer_ids"
+                    )
+                    svls = svls.filtered(lambda l: not l.l10n_ro_invoice_line_id)
+                    svls.write(
+                        {
+                            "l10n_ro_invoice_line_id": line.id,
+                            "l10n_ro_invoice_id": line.move_id.id,
+                        }
+                    )
+
     def _action_done(self):
         res = super()._action_done()
         l10n_ro_records = self.filtered("is_l10n_ro_record")
@@ -24,4 +43,5 @@ class StockPicking(models.Model):
                     )
                 if invoices:
                     invoices.l10n_ro_fix_price_difference_svl()
+                    self.l10n_ro_set_valuations_invoice_line(invoices)
         return res

--- a/l10n_ro_stock_account_reception_in_progress/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account_reception_in_progress/models/stock_valuation_layer.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2014 Forest and Biomass Romania
+# Copyright (C) 2020 NextERP Romania
+# Copyright (C) 2020 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class StockValuationLayer(models.Model):
+    _name = "stock.valuation.layer"
+    _inherit = ["stock.valuation.layer", "l10n.ro.mixin"]
+
+    def _l10n_ro_can_use_invoice_line_account(self, account):
+        self.ensure_one()
+        if (
+            self.l10n_ro_valued_type in ("reception", "reception_return")
+            and self.l10n_ro_invoice_line_id
+        ):
+            inv_line_account = self.l10n_ro_invoice_line_id.account_id
+            if inv_line_account == account.l10n_ro_reception_in_progress_account_id:
+                return False
+
+        return super()._l10n_ro_can_use_invoice_line_account(account)

--- a/l10n_ro_stock_price_difference/__manifest__.py
+++ b/l10n_ro_stock_price_difference/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting Price Difference",
-    "version": "14.0.5.10.0",
+    "version": "14.0.5.10.1",
     "category": "Localization",
     "summary": "Romania - Stock Accounting Price Difference",
     "author": "NextERP Romania," "Dorin Hongu," "Odoo Community Association (OCA)",

--- a/l10n_ro_stock_price_difference/migrations/14.0.5.10.1/pre-migration.py
+++ b/l10n_ro_stock_price_difference/migrations/14.0.5.10.1/pre-migration.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2023 NextERP Romania
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    openupgrade.logged_query(
+        cr,
+        """
+        UPDATE stock_valuation_layer svl set
+            l10n_ro_invoice_id = lsvl.l10n_ro_invoice_id,
+            l10n_ro_invoice_line_id = lsvl.l10n_ro_invoice_line_id
+        FROM stock_valuation_layer lsvl
+        WHERE
+            svl.stock_valuation_layer_id = lsvl.id and
+            svl.description like '%Price Difference%'
+        """,
+    )

--- a/l10n_ro_stock_price_difference/models/account_move.py
+++ b/l10n_ro_stock_price_difference/models/account_move.py
@@ -132,7 +132,7 @@ class AccountMove(models.Model):
                             _qty_diff,
                         ) = line.l10n_ro_get_stock_valuation_difference()
                         if diff:
-                            line.l10n_ro_modify_stock_valuation(diff)
+                            line.l10n_ro_modify_stock_valuation(diff, line)
 
     def _stock_account_prepare_anglo_saxon_in_lines_vals(self):
         l10n_ro_moves = self.filtered(lambda m: m.company_id.l10n_ro_accounting)

--- a/l10n_ro_stock_price_difference/models/account_move_line.py
+++ b/l10n_ro_stock_price_difference/models/account_move_line.py
@@ -74,7 +74,7 @@ class AccountMoveLine(models.Model):
         qty_diff = inv_qty - valuation_total_qty
         return diff, qty_diff
 
-    def l10n_ro_modify_stock_valuation(self, val_dif):
+    def l10n_ro_modify_stock_valuation(self, val_dif, invoice_line=None):
         # se adauga la evaluarea miscarii de stoc
         if not self.purchase_line_id:
             return 0.0
@@ -106,6 +106,8 @@ class AccountMoveLine(models.Model):
                 "quantity": 0,
                 "remaining_qty": 0,
                 "description": "Price Difference",
+                "l10n_ro_invoice_line_id": invoice_line and invoice_line.id or False,
+                "l10n_ro_invoice_id": invoice_line and invoice_line.move_id.id or False,
             }
         )
 


### PR DESCRIPTION
SVL-urile de price difference trebuie sa aiba setat factura, astfel ca in Stock Sheet Report, la gruparea pe Document (factura) sa fie inglobate si diferente de pret, si astfel sa nu fie diferenta intre valoarea din factura si Stock Sheet Report (grupat pe Document).
Altfel, liniile de diferenta de pret din Stock Sheet Report au ca si Document numarul picking-ului.

+
in reception in progress, sa se seteze invoice_line si invoice_id pe svl-urile create la validare receptie
dar fara sa se puna account_id din valuation = 327
