### PR TITLE
[16.0][UPD] - l10n_ro_partner_create_by_vat use user company country code

### DIFF
--- a/l10n_ro_partner_create_by_vat/models/res_partner.py
+++ b/l10n_ro_partner_create_by_vat/models/res_partner.py
@@ -315,6 +315,10 @@ class ResPartner(models.Model):
                     vat_country = self._l10n_ro_map_vat_country_code(
                         self.country_id.code.upper()
                     )
+                if not vat_country and self.env.user.company_id.country_id:
+                    vat_country = self._l10n_ro_map_vat_country_code(
+                        self.env.user.company_id.country_id.code.upper()
+                    )
                     if not vat_number:
                         vat_number = self.vat
                 if vat_country == "RO":


### PR DESCRIPTION
La preluarea datelor unui partener nou, cand CIFul introdus nu are codul tarii se incearca preluarea tarii din datele partenerului nou. Daca nu se gaseste nici acolo, nu se face call la ANAF.

Acest update propune ca rezervă folosirea tarii companiei utilizatorului care doreste sa preia datele partenerului.