### PR TITLE
[17.0][IMP] Add account propagation functionality to stock locations

### DIFF
--- a/l10n_ro_stock_account/models/stock_location.py
+++ b/l10n_ro_stock_account/models/stock_location.py
@@ -35,3 +35,15 @@ class StockLocation(models.Model):
         domain="[('company_id', '=', current_company_id),"
         "('deprecated', '=', False)]",
     )
+
+    def propagate_account(self):
+        for location in self:
+            children = self.search([("id", "child_of", [location.id])])
+            if not children:
+                continue
+            values = {
+                "l10n_ro_property_account_income_location_id": location.l10n_ro_property_account_income_location_id.id,  # noqa
+                "l10n_ro_property_account_expense_location_id": location.l10n_ro_property_account_expense_location_id.id,  # noqa
+                "l10n_ro_property_stock_valuation_account_id": location.l10n_ro_property_stock_valuation_account_id.id,  # noqa
+            }
+            children.write(values)

--- a/l10n_ro_stock_account/views/stock_location_view.xml
+++ b/l10n_ro_stock_account/views/stock_location_view.xml
@@ -1,36 +1,51 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-        <record id="view_location_form_inherit" model="ir.ui.view">
-            <field name="name">view_location_romania_form</field>
-            <field name="model">stock.location</field>
-            <field name="inherit_id" ref="stock_account.view_location_form_inherit" />
-            <field name="arch" type="xml">
-                <xpath expr="//group[@name='additional_info']" position="after">
-                    <group string="Accounting Information">
-                        <field
+    <record id="view_location_form_inherit" model="ir.ui.view">
+        <field name="name">view_location_romania_form</field>
+        <field name="model">stock.location</field>
+        <field name="inherit_id" ref="stock_account.view_location_form_inherit" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='additional_info']" position="after">
+                <group string="Accounting Information">
+                    <field
                         name="valuation_in_account_id"
                         options="{'no_create': True}"
                     />
-                        <field
+                    <field
                         name="valuation_out_account_id"
                         options="{'no_create': True}"
                     />
-                        <field name="is_l10n_ro_record" invisible="1" />
-                        <separator string="Only for Romania" />
-                        <field
+                    <field name="is_l10n_ro_record" invisible="1" />
+                    <separator string="Only for Romania" />
+                    <field
                         name="l10n_ro_property_account_income_location_id"
                         options="{'no_create': True}"
                     />
-                        <field
+                    <field
                         name="l10n_ro_property_account_expense_location_id"
                         options="{'no_create': True}"
                     />
-                        <field
+                    <field
                         name="l10n_ro_property_stock_valuation_account_id"
                         options="{'no_create': True}"
                     />
-                    </group>
-                </xpath>
-            </field>
-        </record>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+
+    <record id="action_location_account_propagate" model="ir.actions.server">
+        <field name="name">Propagate Accounts</field>
+        <field name="model_id" ref="model_stock_location" />
+        <field name="binding_model_id" ref="model_stock_location" />
+        <field name="binding_view_types">form</field>
+        <field name="groups_id" eval="[(4, ref('base.group_no_one'))]" />
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                records.propagate_account()
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Introduced a new server action to propagate accounts from parent stock locations to their children. This includes income, expense, and stock valuation accounts. The `propagate_account` method handles the logic, enabling efficient and consistent account assignment across stock location hierarchies.