### PR TITLE
[17.0][IMP] Refactor ANAF history groups in partner views

### DIFF
--- a/l10n_ro_partner_create_by_vat/views/partner_view.xml
+++ b/l10n_ro_partner_create_by_vat/views/partner_view.xml
@@ -24,14 +24,14 @@
             <field name="arch" type="xml">
                 <page name="accounting" position="inside">
                     <field name="is_l10n_ro_record" invisible="1" />
-                    <group string="ANAF History">
-                        <separator string="ANAF - Active State History" />
+                    <group string="ANAF - Active State History">
+
                         <field
                         name="l10n_ro_active_anaf_line_ids"
                         readonly="1"
                         force_save="1"
                         nolabel="1"
-                        colspan="4"
+                        colspan="2"
                     >
                             <tree>
                                 <field name="partner_id" invisible="1" />
@@ -45,13 +45,14 @@
                                 <field name="active_status" />
                             </tree>
                         </field>
-                        <separator string="ANAF - VAT Subjected History" />
+                    </group>
+                    <group string="ANAF - VAT Subjected History">
                         <field
                         name="l10n_ro_vat_subjected_anaf_line_ids"
                         readonly="1"
                         force_save="1"
                         nolabel="1"
-                        colspan="4"
+                        colspan="2"
                     >
                             <tree>
                                 <field name="partner_id" invisible="1" />

--- a/l10n_ro_vat_on_payment/views/res_partner_view.xml
+++ b/l10n_ro_vat_on_payment/views/res_partner_view.xml
@@ -61,9 +61,9 @@
         <field name="arch" type="xml">
             <page name="accounting" position="inside">
                 <field name="is_l10n_ro_record" invisible="1" />
-                <group id="l10n_ro_anaf_history_group">
-                    <separator string="ANAF - VAT on Payment" />
-                    <field name="l10n_ro_anaf_history" nolabel="1" colspan="4">
+                <group string="ANAF - VAT on Payment" id="l10n_ro_anaf_history_group">
+
+                    <field name="l10n_ro_anaf_history" nolabel="1" colspan="2">
                         <tree>
                             <field name="start_date" />
                             <field name="end_date" />


### PR DESCRIPTION
Reorganized and renamed group definitions for better clarity and consistency across partner views. Adjusted colspan values to standardize layout and improve visual alignment. These changes enhance the user interface without altering functionality.