### PR TITLE
[16.0][FIX] Set correct standard for invoice type in ANAF processing

### DIFF
--- a/l10n_ro_account_edi_ubl/models/account_edi_format.py
+++ b/l10n_ro_account_edi_ubl/models/account_edi_format.py
@@ -262,7 +262,8 @@ class AccountEdiXmlCIUSRO(models.Model):
 
     def _l10n_ro_post_invoice_step_1(self, invoice, attachment):
         anaf_config = invoice.company_id._l10n_ro_get_anaf_sync(scope="e-factura")
-        standard = "UBL"
+        standard = "UBL" if invoice.move_type == "out_invoice" else "CN"
+
         params = {
             "standard": standard,
             "cif": invoice.company_id.partner_id.vat.replace("RO", ""),


### PR DESCRIPTION
Changed the EDI format standard to "CN" for credit notes while retaining "UBL" for outgoing invoices. This ensures compatibility with ANAF requirements based on the invoice type.