### PR TITLE
[17.0][FIX] Restrict VAT checks and updates to companies only.

### DIFF
--- a/l10n_ro_partner_create_by_vat/models/res_partner.py
+++ b/l10n_ro_partner_create_by_vat/models/res_partner.py
@@ -75,6 +75,8 @@ class ResPartner(models.Model):
     def check_vat(self):
         if self.env.context.get("no_vat_validation"):
             return
+        if not self.is_company:
+            return
         partners = self.filtered(lambda p: p.country_id.code == "RO")
         # if partners:
         #     partners._check_vat_ro()
@@ -312,7 +314,7 @@ class ResPartner(models.Model):
     @api.onchange("vat", "country_id")
     def ro_vat_change(self):
         res = {}
-        if self.is_l10n_ro_record and not self.parent_id:
+        if self.is_l10n_ro_record and not self.parent_id and self.is_company:
             if not self.env.context.get("skip_ro_vat_change"):
                 if not self.vat:
                     return res

--- a/l10n_ro_partner_create_by_vat/models/res_partner.py
+++ b/l10n_ro_partner_create_by_vat/models/res_partner.py
@@ -75,8 +75,6 @@ class ResPartner(models.Model):
     def check_vat(self):
         if self.env.context.get("no_vat_validation"):
             return
-        if not self.is_company:
-            return
         partners = self.filtered(lambda p: p.country_id.code == "RO")
         # if partners:
         #     partners._check_vat_ro()

--- a/l10n_ro_partner_create_by_vat/tests/test_create_partner_by_vat.py
+++ b/l10n_ro_partner_create_by_vat/tests/test_create_partner_by_vat.py
@@ -69,6 +69,7 @@ class TestCreatePartner(TestCreatePartnerBase):
         # Test onchange from ANAF
 
         mainpartner = Form(self.mainpartner)
+        mainpartner.company_type = "company"
         mainpartner.vat = "RO30834857"
         self.assertEqual(mainpartner.name, "FOREST AND BIOMASS ROMÂNIA S.A.")
         self.assertEqual(mainpartner.street, "Str. Ciprian Porumbescu Nr. 12")
@@ -158,6 +159,7 @@ class TestCreatePartner(TestCreatePartnerBase):
         error, res = self.mainpartner._get_Anaf("20603502")
         self.assertEqual(res, {})
         self.assertTrue(len(error) > 3)
+        self.mainpartner.company_type = "company"
         self.mainpartner.vat = "RO20603502"
         res = self.mainpartner.ro_vat_change()
         self.assertTrue(res.get("warning"))


### PR DESCRIPTION
This update ensures that VAT validation and changes are applied only to records marked as companies. It prevents unnecessary operations for non-company partners, improving efficiency and avoiding potential errors.