### PR TITLE
[17.0][IMP] Refactor partner retrieval logic in l10n_ro_message_spv.

### DIFF
--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 import pytz
 
-from odoo import api, models
+from odoo import models
 
 _logger = logging.getLogger(__name__)
 
@@ -15,7 +15,6 @@ _logger = logging.getLogger(__name__)
 class ResCompany(models.Model):
     _inherit = "res.company"
 
-    @api.model
     def l10n_ro_download_message_spv(self):
         # method to be used in cron job to auto download e-invoices from ANAF
 
@@ -29,12 +28,22 @@ class ResCompany(models.Model):
             if not partner:
                 domain = [("vat", "like", cif), ("is_company", "=", True)]
                 partner = self.env["res.partner"].search(domain, limit=1)
-                if not partner:
-                    domain = [("vat", "like", cif)]
-                    partner = self.env["res.partner"].search(domain, limit=1)
+            if not partner:
+                domain = [("vat", "like", cif)]
+                partner = self.env["res.partner"].search(domain, limit=1)
+            if not partner:
+                partner = self.env["res.partner"].create(
+                    {
+                        "name": "Unknown",
+                        "vat": cif,
+                        "company_id": self.id,
+                        "country_id": self.env.ref("base.ro").id,
+                        "is_company": True,
+                    }
+                )
             return partner
 
-        ro_companies = self.env.user.company_ids.filtered(
+        ro_companies = self or self.env.user.company_ids.filtered(
             lambda c: c.l10n_ro_edi_access_token
         )
 

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -18,6 +18,22 @@ class ResCompany(models.Model):
     @api.model
     def l10n_ro_download_message_spv(self):
         # method to be used in cron job to auto download e-invoices from ANAF
+
+        def get_partner_from_cif(cif):
+            domain = [
+                ("vat", "like", cif),
+                ("is_company", "=", True),
+                ("company_id", "=", self.id),
+            ]
+            partner = self.env["res.partner"].search(domain, limit=1)
+            if not partner:
+                domain = [("vat", "like", cif), ("is_company", "=", True)]
+                partner = self.env["res.partner"].search(domain, limit=1)
+                if not partner:
+                    domain = [("vat", "like", cif)]
+                    partner = self.env["res.partner"].search(domain, limit=1)
+            return partner
+
         ro_companies = self.env.user.company_ids.filtered(
             lambda c: c.l10n_ro_edi_access_token
         )
@@ -51,17 +67,14 @@ class ResCompany(models.Model):
                         match = re.search(pattern_in, message["detalii"])
                         if match:
                             cif = match.group(1)
-                            partner = self.env["res.partner"].search(
-                                [("vat", "like", cif)], limit=1
-                            )
+                            partner = get_partner_from_cif(cif)
 
                     elif message["tip"] == "FACTURA TRIMISA":
                         message_type = "out_invoice"
                         match = re.search(pattern_out, message["detalii"])
                         if match:
                             cif = match.group(1)
-                            domain = [("vat", "like", cif), ("is_company", "=", True)]
-                            partner = self.env["res.partner"].search(domain, limit=1)
+                            partner = get_partner_from_cif(cif)
                     elif message["tip"] == "ERORI FACTURA":
                         message_type = "error"
                     elif "MESAJ" in message["tip"]:

--- a/l10n_ro_message_spv/tests/common.py
+++ b/l10n_ro_message_spv/tests/common.py
@@ -18,6 +18,7 @@ class TestMessageSPV(AccountEdiTestCommon, CronMixinCase):
         cls.mainpartner = cls.env.ref("base.main_partner")
         cls.env.company.anglo_saxon_accounting = True
         cls.env.company.l10n_ro_accounting = True
+        cls.env.company.l10n_ro_edi_access_token = "123"
 
         # Set up company details
         cls.currency = cls.env["res.currency"].search([("name", "=", "RON")])

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -17,6 +17,7 @@ class TestMessageSPV(TestMessageSPV):
     def test_download_messages(self):
         # test de descarcare a mesajelor de la SPV
         self.env.company.vat = "RO23685159"
+
         msg_dict = {
             "mesaje": [
                 {


### PR DESCRIPTION
Encapsulated the CIF-based partner search logic into a reusable `get_partner_from_cif` method. This reduces code duplication and improves maintainability when identifying partners based on VAT numbers in SPV messages.