### PR TITLE
Set 'l10n_ro_edi_state' to False on invoice send failure.

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -272,6 +272,7 @@ class MessageSPV(models.Model):
                 edi_doc.write(
                     {"state": "invoice_sending_failed", "message": message.error}
                 )
+                edi_doc.invoice_id.write({"l10n_ro_edi_state": False})
 
         messages = self.filtered(lambda m: not m.invoice_id)
         messages_without_invoice = messages.filtered(lambda m: not m.invoice_id)


### PR DESCRIPTION
This change ensures that the `l10n_ro_edi_state` field is updated to reflect the failure state when an invoice sending error occurs. It adds robustness to the error handling logic and keeps the invoice state consistent.