### PR TITLE
[17.0][IMP] Eliminare is_l10n_ro_record din views

### DIFF
--- a/l10n_ro_account_period_close/views/account_period_close_view.xml
+++ b/l10n_ro_account_period_close/views/account_period_close_view.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="account.view_account_form" />
         <field name="arch" type="xml">
             <field position="after" name="deprecated">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_close_check" />
             </field>
         </field>
@@ -100,6 +99,5 @@
         <field name="action" ref="action_account_period_closing" />
         <field name="parent_id" ref="account.menu_finance_entries_actions" />
         <field name="groups_id" eval="[(4, ref('l10n_ro_config.group_ro_menus'))]" />
-        <field name="is_l10n_ro_record" eval="True" />
     </record>
 </odoo>

--- a/l10n_ro_account_report_invoice/views/account_invoice_view.xml
+++ b/l10n_ro_account_report_invoice/views/account_invoice_view.xml
@@ -7,11 +7,11 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <div name="journal_div" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <label
                     for="l10n_ro_currency_rate"
                     groups="account.group_account_readonly"
-                    invisible="context.get('default_journal_id') and context.get('move_type', 'entry') != 'entry' and is_l10n_ro_record == False"
+                    invisible="context.get('default_journal_id') and context.get('move_type', 'entry') != 'entry'  "
                 />
                 <div
                     name="currency_rate_div"
@@ -19,18 +19,14 @@
                     invisible="context.get('default_journal_id') and context.get('move_type', 'entry') != 'entry'"
                     groups="account.group_account_readonly"
                 >
-                    <field
-                        name="l10n_ro_currency_rate"
-                        digits="[16, 4]"
-                        invisible="is_l10n_ro_record == False"
-                    />
+                    <field name="l10n_ro_currency_rate" digits="[16, 4]" />
                 </div>
             </div>
             <group name="accounting_info_group" position="after">
                 <group
                     string="Amounts in company currency"
                     groups="base.group_multi_currency"
-                    invisible="is_l10n_ro_record == False"
+                    id="l10n_ro_multi_currency"
                 >
                     <field name="amount_untaxed_signed" string="Tax Excluded" />
                     <field name="amount_tax_signed" string="Tax" />

--- a/l10n_ro_account_report_invoice/views/res_config_settings_view.xml
+++ b/l10n_ro_account_report_invoice/views/res_config_settings_view.xml
@@ -6,10 +6,9 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <block id="invoicing_settings" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <div
+                    id="l10n_ro_invoicing_settings"
                     class="col-12 col-lg-6 o_setting_box"
-                    invisible="is_l10n_ro_record == False"
                 >
                     <div class="o_setting_left_pane">
                     </div>

--- a/l10n_ro_city/views/res_city_view.xml
+++ b/l10n_ro_city/views/res_city_view.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="base_address_extended.view_city_tree" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_municipality" />
                 <field name="l10n_ro_siruta" />
             </field>

--- a/l10n_ro_config/views/account_journal.xml
+++ b/l10n_ro_config/views/account_journal.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="account.view_account_journal_tree" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="is_l10n_ro_record" column_invisible="1" />
                 <field name="l10n_ro_print_report" />
             </field>
         </field>
@@ -17,15 +16,13 @@
         <field name="inherit_id" ref="account.view_account_journal_form" />
         <field name="arch" type="xml">
             <xpath expr="//group/field[@name='company_id']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_print_report" readonly="False" />
                 <field name="l10n_ro_fiscal_receipt" />
             </xpath>
             <xpath expr="//group[@name='group_alias_edit']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <group
                     string="Ro Auto Invoicing"
-                    invisible="is_l10n_ro_record == False or type not in ['sale', 'purchase']"
+                    invisible="type not in ['sale', 'purchase']"
                 >
                     <field name="l10n_ro_sequence_type" />
                     <field name="l10n_ro_partner_id" />

--- a/l10n_ro_config/views/res_bank_view.xml
+++ b/l10n_ro_config/views/res_bank_view.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="base.view_partner_bank_form" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_print_report" />
             </field>
         </field>
@@ -17,7 +16,6 @@
         <field name="inherit_id" ref="base.view_partner_bank_tree" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_print_report" />
             </field>
         </field>

--- a/l10n_ro_config/views/res_partner_view.xml
+++ b/l10n_ro_config/views/res_partner_view.xml
@@ -5,9 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <form position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
-            </form>
+
             <field name="nrc" position="attributes">
                 <attribute name="invisible">not is_company</attribute>
             </field>

--- a/l10n_ro_config/wizard/res_config_settings_views.xml
+++ b/l10n_ro_config/wizard/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <form position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <field
                     name="country_code"
                     invisible="1"

--- a/l10n_ro_dvi/views/account_dvi_view.xml
+++ b/l10n_ro_dvi/views/account_dvi_view.xml
@@ -157,7 +157,6 @@
         <field name="action" ref="action_account_dvi" />
         <field name="parent_id" ref="account.menu_finance_entries_actions" />
         <field name="groups_id" eval="[(4, ref('base.group_no_one'))]" />
-        <field name="is_l10n_ro_record" eval="True" />
         <field name="sequence" eval="45" />
     </record>
 </odoo>

--- a/l10n_ro_dvi/views/account_invoice_view.xml
+++ b/l10n_ro_dvi/views/account_invoice_view.xml
@@ -7,14 +7,14 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <field name="l10n_ro_dvi_ids" invisible="1" />
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <button
                     name="action_view_dvis"
                     string="DVI"
                     class="oe_stat_button"
                     icon="fa-bars"
                     type="object"
-                    invisible="not l10n_ro_dvi_ids and not is_l10n_ro_record"
+                    invisible="not l10n_ro_dvi_ids and "
                 />
             </div>
         </field>

--- a/l10n_ro_dvi/views/account_invoice_view.xml
+++ b/l10n_ro_dvi/views/account_invoice_view.xml
@@ -14,7 +14,7 @@
                     class="oe_stat_button"
                     icon="fa-bars"
                     type="object"
-                    invisible="not l10n_ro_dvi_ids and "
+                    invisible="not l10n_ro_dvi_ids"
                 />
             </div>
         </field>

--- a/l10n_ro_dvi/views/stock_landed_cost_view.xml
+++ b/l10n_ro_dvi/views/stock_landed_cost_view.xml
@@ -8,12 +8,7 @@
             ref="l10n_ro_stock_account_landed_cost.view_stock_landed_cost_form"
         />
         <field name="arch" type="xml">
-            <group name="l10n_ro_general" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
-            </group>
-            <group name="l10n_ro_general" position="attributes">
-                <attribute name="invisible">not is_l10n_ro_record</attribute>
-            </group>
+
             <group name="l10n_ro_general" position="inside">
                 <field
                     name="l10n_ro_account_dvi_id"
@@ -26,10 +21,7 @@
                 />
             </group>
             <group name="l10n_ro_general" position="after">
-                <group
-                    name="l10n_ro_dvi"
-                    invisible="l10n_ro_cost_type != 'dvi' or is_l10n_ro_record == False"
-                >
+                <group name="l10n_ro_dvi" invisible="l10n_ro_cost_type != 'dvi' ">
                     <field name="l10n_ro_tax_id" readonly="state == 'done'" />
                     <field name="l10n_ro_base_tax_value" readonly="state == 'done'" />
                     <field name="l10n_ro_tax_value" readonly="state == 'done'" />

--- a/l10n_ro_nondeductible_vat/views/account_account_view.xml
+++ b/l10n_ro_nondeductible_vat/views/account_account_view.xml
@@ -7,11 +7,8 @@
         <field name="inherit_id" ref="account.view_account_form" />
         <field name="arch" type="xml">
             <field name="tax_ids" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
-                <field
-                    name="l10n_ro_nondeductible_account_id"
-                    invisible="is_l10n_ro_record == False"
-                />
+
+                <field name="l10n_ro_nondeductible_account_id" />
             </field>
         </field>
     </record>

--- a/l10n_ro_nondeductible_vat/views/account_tax_view.xml
+++ b/l10n_ro_nondeductible_vat/views/account_tax_view.xml
@@ -8,11 +8,11 @@
         <field name="inherit_id" ref="account.view_tax_form" />
         <field name="arch" type="xml">
             <field name="cash_basis_transition_account_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <field name="l10n_ro_is_nondeductible" invisible="1" />
                 <field
                     name="l10n_ro_nondeductible_tax_id"
-                    invisible="is_l10n_ro_record == False or l10n_ro_is_nondeductible == False"
+                    invisible=" l10n_ro_is_nondeductible == False"
                     domain="[('l10n_ro_is_nondeductible','=',True)]"
                 />
             </field>
@@ -29,21 +29,18 @@
         <field name="inherit_id" ref="account.tax_repartition_line_tree" />
         <field name="arch" type="xml">
             <field name="repartition_type" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
 
                 <field
                     name="l10n_ro_nondeductible"
-                    column_invisible="parent.is_l10n_ro_record == False"
                     invisible="repartition_type == 'base'"
                 />
                 <field
                     name="l10n_ro_exclude_from_stock"
-                    column_invisible="parent.is_l10n_ro_record == False"
                     invisible="repartition_type == 'base'"
                 />
                 <field
                     name="l10n_ro_skip_cash_basis_account_switch"
-                    column_invisible="parent.is_l10n_ro_record == False"
                     invisible="repartition_type == 'base'"
                 />
             </field>

--- a/l10n_ro_nondeductible_vat/views/stock_picking_view.xml
+++ b/l10n_ro_nondeductible_vat/views/stock_picking_view.xml
@@ -6,14 +6,12 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field eval="42" name="priority" />
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
-            </field>
+
             <xpath expr="//button[@name='action_assign_serial']" position="before">
                 <field name="l10n_ro_nondeductible_usage" column_invisible="1" />
                 <field
                     name="l10n_ro_nondeductible_tax_id"
-                    column_invisible="parent.is_l10n_ro_record == False or parent.picking_type_code != 'internal'"
+                    column_invisible=" parent.picking_type_code != 'internal'"
                     invisible="l10n_ro_nondeductible_usage == False"
                 />
             </xpath>

--- a/l10n_ro_nondeductible_vat/views/stock_quant_view.xml
+++ b/l10n_ro_nondeductible_vat/views/stock_quant_view.xml
@@ -7,10 +7,10 @@
         <field name="inherit_id" ref="stock.view_stock_quant_tree_inventory_editable" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='inventory_diff_quantity']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <field
                     name="l10n_ro_nondeductible_tax_id"
-                    invisible="is_l10n_ro_record == False or inventory_diff_quantity &gt;= 0.00"
+                    invisible=" inventory_diff_quantity &gt;= 0.00"
                 />
             </xpath>
         </field>

--- a/l10n_ro_partner_create_by_vat/views/partner_view.xml
+++ b/l10n_ro_partner_create_by_vat/views/partner_view.xml
@@ -23,8 +23,11 @@
             <field name="inherit_id" ref="account.view_partner_property_form" />
             <field name="arch" type="xml">
                 <page name="accounting" position="inside">
-                    <field name="is_l10n_ro_record" invisible="1" />
-                    <group string="ANAF - Active State History">
+
+                    <group
+                    string="ANAF - Active State History"
+                    id="l10n_ro_anaf_active_stare_history"
+                >
 
                         <field
                         name="l10n_ro_active_anaf_line_ids"
@@ -46,7 +49,10 @@
                             </tree>
                         </field>
                     </group>
-                    <group string="ANAF - VAT Subjected History">
+                    <group
+                    string="ANAF - VAT Subjected History"
+                    id="l10n_ro_anaf_active_vat_history"
+                >
                         <field
                         name="l10n_ro_vat_subjected_anaf_line_ids"
                         readonly="1"

--- a/l10n_ro_payment_to_statement/views/account_journal_view.xml
+++ b/l10n_ro_payment_to_statement/views/account_journal_view.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="account.view_account_journal_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='refund_sequence']" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_journal_sequence_id" />
                 <field
                     name="l10n_ro_customer_cash_in_sequence_id"

--- a/l10n_ro_payment_to_statement/views/account_payment_view.xml
+++ b/l10n_ro_payment_to_statement/views/account_payment_view.xml
@@ -6,14 +6,16 @@
         <field name="inherit_id" ref="account.view_account_payment_form" />
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <button
+                    id="l10n_ro_get_l10n_ro_statement_line"
                     name="get_l10n_ro_statement_line"
                     string="Add to statement"
                     type="object"
                     invisible="state != 'posted'"
                 />
                 <button
+                    id="l10n_ro_get_l10n_ro_reconciled_statement_line"
                     name="get_l10n_ro_reconciled_statement_line"
                     string="Get statement Line"
                     type="object"
@@ -21,7 +23,6 @@
                 />
             </xpath>
             <xpath expr="//group[@name='group2']" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_statement_id" />
                 <field name="statement_line_id" />
             </xpath>

--- a/l10n_ro_stock/views/stock_location_view.xml
+++ b/l10n_ro_stock/views/stock_location_view.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="stock.view_location_form" />
         <field name="arch" type="xml">
             <field name="usage" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_merchandise_type" />
             </field>
         </field>
@@ -17,7 +16,6 @@
         <field name="inherit_id" ref="stock.view_location_search" />
         <field name="arch" type="xml">
             <field name="complete_name" position="after">
-
                 <field name="l10n_ro_merchandise_type" />
             </field>
         </field>
@@ -28,7 +26,6 @@
         <field name="inherit_id" ref="stock.view_location_tree2" />
         <field name="arch" type="xml">
             <field name="usage" position="after">
-                <field name="is_l10n_ro_record" column_invisible="1" />
                 <field name="l10n_ro_merchandise_type" />
             </field>
         </field>

--- a/l10n_ro_stock/views/stock_warehouse_view.xml
+++ b/l10n_ro_stock/views/stock_warehouse_view.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="stock.view_warehouse" />
         <field name="arch" type="xml">
             <field name="wh_output_stock_loc_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_wh_consume_loc_id" readonly="1" />
                 <field name="l10n_ro_wh_usage_loc_id" readonly="1" />
             </field>

--- a/l10n_ro_stock_account/views/account_account_view.xml
+++ b/l10n_ro_stock_account/views/account_account_view.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="account.view_account_form" />
         <field name="arch" type="xml">
             <field name="tax_ids" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_stock_consume_account_id" />
             </field>
         </field>

--- a/l10n_ro_stock_account/views/product_category_view.xml
+++ b/l10n_ro_stock_account/views/product_category_view.xml
@@ -7,7 +7,6 @@
         <field name="priority" eval="50" />
         <field name="arch" type="xml">
             <field name="property_stock_valuation_account_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_stock_account_change" />
                 <field name="l10n_ro_hide_stock_in_out_account" invisible="1" />
             </field>

--- a/l10n_ro_stock_account/views/product_template_view.xml
+++ b/l10n_ro_stock_account/views/product_template_view.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="account.product_template_form_view" />
         <field name="arch" type="xml">
             <field name="property_account_expense_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field
                     name="l10n_ro_property_stock_valuation_account_id"
                     domain="[('deprecated','=',False)]"

--- a/l10n_ro_stock_account/views/stock_location_view.xml
+++ b/l10n_ro_stock_account/views/stock_location_view.xml
@@ -15,7 +15,7 @@
                         name="valuation_out_account_id"
                         options="{'no_create': True}"
                     />
-                    <field name="is_l10n_ro_record" invisible="1" />
+
                     <separator string="Only for Romania" />
                     <field
                         name="l10n_ro_property_account_income_location_id"

--- a/l10n_ro_stock_account/views/stock_picking_view.xml
+++ b/l10n_ro_stock_account/views/stock_picking_view.xml
@@ -6,12 +6,10 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_assign_serial']" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="picking_code" invisible="1" />
                 <field name="price_unit" invisible="picking_code != 'incoming'" />
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <button
                     string="Journal Items"
                     type="object"

--- a/l10n_ro_stock_account/views/stock_valuation_layer_views.xml
+++ b/l10n_ro_stock_account/views/stock_valuation_layer_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="stock_account.stock_valuation_layer_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='stock_move_id']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <field name="l10n_ro_valued_type" />
 
             </xpath>

--- a/l10n_ro_stock_account_date/views/stock_picking_views.xml
+++ b/l10n_ro_stock_account_date/views/stock_picking_views.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="stock.vpicktree" />
         <field name="arch" type="xml">
             <field name="scheduled_date" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_accounting_date" readonly="1" />
             </field>
         </field>
@@ -17,7 +16,6 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <xpath expr="//label[@for='scheduled_date']" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <label for="l10n_ro_accounting_date" />
                 <div class="o_row">
                     <field name="l10n_ro_accounting_date" readonly="state == 'done'" />

--- a/l10n_ro_stock_account_date/views/stock_valuation_layer_views.xml
+++ b/l10n_ro_stock_account_date/views/stock_valuation_layer_views.xml
@@ -5,7 +5,6 @@
         <field name="priority">290</field>
         <field name="arch" type="xml">
             <field name="create_date" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_date_done" />
             </field>
         </field>

--- a/l10n_ro_stock_account_date_wizard/wizard/stock_backorder_confirmation_views.xml
+++ b/l10n_ro_stock_account_date_wizard/wizard/stock_backorder_confirmation_views.xml
@@ -6,7 +6,6 @@
         <field name="arch" type="xml">
             <xpath expr="//footer" position="before">
                 <group>
-                    <field name="is_l10n_ro_record" invisible="1" />
                     <field name="l10n_ro_accounting_date" />
                 </group>
             </xpath>

--- a/l10n_ro_stock_account_landed_cost/views/stock_landed_cost_view.xml
+++ b/l10n_ro_stock_account_landed_cost/views/stock_landed_cost_view.xml
@@ -9,7 +9,7 @@
             />
             <field name="arch" type="xml">
                 <notebook position="before">
-                    <group name="l10n_ro_extend" invisible="is_l10n_ro_record == False">
+                    <group name="l10n_ro_extend">
                         <group name="l10n_ro_general">
                             <field
                                 name="l10n_ro_cost_type"

--- a/l10n_ro_stock_account_landed_cost/views/stock_landed_cost_view.xml
+++ b/l10n_ro_stock_account_landed_cost/views/stock_landed_cost_view.xml
@@ -9,7 +9,6 @@
             />
             <field name="arch" type="xml">
                 <notebook position="before">
-                    <field name="is_l10n_ro_record" invisible="1" />
                     <group name="l10n_ro_extend" invisible="is_l10n_ro_record == False">
                         <group name="l10n_ro_general">
                             <field

--- a/l10n_ro_stock_account_notice/views/stock_picking_view.xml
+++ b/l10n_ro_stock_account_notice/views/stock_picking_view.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <field name="backorder_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_notice" readonly="state in ('done', 'cancel')" />
             </field>
             <!-- if is a notice/aviz to be mandatory the partner_id -->
@@ -21,7 +20,6 @@
         <field name="inherit_id" ref="stock.vpicktree" />
         <field name="arch" type="xml">
             <field name="origin" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_notice" optional="show" />
             </field>
         </field>
@@ -32,7 +30,6 @@
         <field name="inherit_id" ref="stock.view_picking_internal_search" />
         <field name="arch" type="xml">
             <filter name="backorder" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <filter
                     name="notice"
                     string="Is notice"
@@ -48,11 +45,9 @@
         <field name="inherit_id" ref="stock.stock_picking_kanban" />
         <field name="arch" type="xml">
             <field name="activity_state" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_notice" />
             </field>
             <xpath expr="//div[hasclass('o_kanban_record_bottom')]" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <div class="oe_kanban_content">
                     <label for="l10n_ro_notice">Is notice</label>
                     <field

--- a/l10n_ro_stock_account_reception_in_progress/views/account_account_view.xml
+++ b/l10n_ro_stock_account_reception_in_progress/views/account_account_view.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="account.view_account_form" />
         <field name="arch" type="xml">
             <field name="tax_ids" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_reception_in_progress_account_id" />
             </field>
         </field>

--- a/l10n_ro_stock_account_reception_in_progress/views/purchase_order_view.xml
+++ b/l10n_ro_stock_account_reception_in_progress/views/purchase_order_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
             <button name="action_create_invoice" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <button
                     name="action_create_reception_in_progress_invoice"
                     string="Reception in Progress"
@@ -14,7 +14,7 @@
                     type="object"
                     class="oe_highlight"
                     context="{'create_bill':True}"
-                    invisible="(not is_l10n_ro_record and state != 'purchase') or invoice_status != 'no'"
+                    invisible="( state != 'purchase') or invoice_status != 'no'"
                 />
             </button>
         </field>

--- a/l10n_ro_stock_account_tracking/views/stock_valuation_layer_views.xml
+++ b/l10n_ro_stock_account_tracking/views/stock_valuation_layer_views.xml
@@ -5,11 +5,11 @@
         <field name="inherit_id" ref="stock_account.stock_valuation_layer_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='stock_move_id']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <field name="l10n_ro_valued_type" />
                 <field
                     name="l10n_ro_stock_move_line_id"
-                    invisible="is_l10n_ro_record == False or l10n_ro_stock_move_line_id == False"
+                    invisible=" l10n_ro_stock_move_line_id == False"
                 />
                 <field name="l10n_ro_location_id" />
                 <field name="l10n_ro_location_dest_id" />
@@ -21,11 +21,7 @@
                 <field name="l10n_ro_invoice_id" />
             </xpath>
             <xpath expr="//page[@name='other_info']" position="after">
-                    <page
-                    string="Source SVL"
-                    name="source_svl"
-                    invisible="is_l10n_ro_record == False"
-                >
+                    <page string="Source SVL" name="source_svl">
                         <label for="l10n_ro_svl_src_ids" />
                         <field name="l10n_ro_svl_src_ids" readonly="1">
                             <tree>
@@ -37,11 +33,7 @@
                             </tree>
                         </field>
                     </page>
-                    <page
-                    string="Destination SVL"
-                    name="destination_svl"
-                    invisible="is_l10n_ro_record == False"
-                >
+                    <page string="Destination SVL" name="destination_svl">
                         <label for="l10n_ro_svl_dest_ids" />
                         <field name="l10n_ro_svl_dest_ids" readonly="1">
                             <tree>

--- a/l10n_ro_stock_account_tracking/wizard/stock_valuation_layer_revaluation_views.xml
+++ b/l10n_ro_stock_account_tracking/wizard/stock_valuation_layer_revaluation_views.xml
@@ -10,7 +10,6 @@
         />
         <field name="arch" type="xml">
             <xpath expr="//group[1]" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <group id="l10n_ro_location_group">
                     <label for="l10n_ro_location_id" string="Location" />
                     <div class="o_row">

--- a/l10n_ro_stock_picking_comment_template/views/base_comment_template_view.xml
+++ b/l10n_ro_stock_picking_comment_template/views/base_comment_template_view.xml
@@ -17,7 +17,6 @@
         <field name="name">Romanian Stock Picking Comments</field>
         <field name="action" ref="action_stock_picking_comment_template" />
         <field name="parent_id" ref="stock.menu_stock_config_settings" />
-        <field name="is_l10n_ro_record" eval="True" />
     </record>
 
 </odoo>

--- a/l10n_ro_stock_picking_comment_template/views/stock_picking_view.xml
+++ b/l10n_ro_stock_picking_comment_template/views/stock_picking_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <field name="group_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
+
                 <field
                     name="l10n_ro_delegate_id"
                     domain="[('type','=','contact'),('is_company','=',False)]"
@@ -24,12 +24,8 @@
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <xpath expr="//notebook" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
-                <page
-                    string="Comments"
-                    name="comments"
-                    invisible="is_l10n_ro_record == False"
-                >
+
+                <page id="l10n_ro_comments" string="Comments" name="comments">
                     <field name="comment_template_ids" />
                 </page>
             </xpath>

--- a/l10n_ro_stock_report/report/stock_report_view.xml
+++ b/l10n_ro_stock_report/report/stock_report_view.xml
@@ -202,7 +202,6 @@
         <field name="action" ref="action_sheet_stock_report" />
         <field name="parent_id" ref="stock.menu_warehouse_report" />
         <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />
-        <field name="is_l10n_ro_record" eval="True" />
     </record>
 
     <record id="action_sheet_stock_report_line" model="ir.actions.act_window">

--- a/l10n_ro_vat_on_payment/views/res_partner_view.xml
+++ b/l10n_ro_vat_on_payment/views/res_partner_view.xml
@@ -29,12 +29,12 @@
         <field name="inherit_id" ref="l10n_ro_config.view_partner_create_by_vat" />
         <field name="arch" type="xml">
             <field name="l10n_ro_vat_number" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <label
                     for="l10n_ro_vat_on_payment"
                     invisible="vat == False or company_type != 'company'"
                 />
                 <div
+                    id="l10n_ro_vat_on_payment_info"
                     name="vat_on_payment_info"
                     class="o_row"
                     invisible="vat == False or company_type != 'company'"
@@ -60,9 +60,7 @@
         <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="arch" type="xml">
             <page name="accounting" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <group string="ANAF - VAT on Payment" id="l10n_ro_anaf_history_group">
-
                     <field name="l10n_ro_anaf_history" nolabel="1" colspan="2">
                         <tree>
                             <field name="start_date" />


### PR DESCRIPTION
This commit removes occurrences of the `is_l10n_ro_record` field across multiple XML views as it is no longer in use. This cleanup aims to reduce unnecessary elements in the codebase and improve maintainability.