### PR TITLE
[16.0][IMP] mail activity type speccific pentru erorile efactura

### DIFF
--- a/l10n_ro_account_edi_ubl/__manifest__.py
+++ b/l10n_ro_account_edi_ubl/__manifest__.py
@@ -14,6 +14,7 @@
         "security/ir.model.access.csv",
         "data/account_edi_data.xml",
         "data/ubl_templates.xml",
+        "data/mail_activity_data.xml",
         "views/res_config_settings_views.xml",
         "views/account_invoice.xml",
         "views/product_view.xml",

--- a/l10n_ro_account_edi_ubl/data/mail_activity_data.xml
+++ b/l10n_ro_account_edi_ubl/data/mail_activity_data.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
-    <data noupdate="1">
-        <record id="mail_activity_einvoice_data_warning" model="mail.activity.type">
-            <field name="name">EInvoice Exception</field>
-            <field name="icon">fa-warning</field>
-            <field name="delay_count">0</field>
-            <field name="sequence">100</field>
-            <field name="decoration_type">warning</field>
-            <field name="active">False</field>
-        </record>
-    </data>
+<odoo noupdate="1">
+    <record id="mail_activity_einvoice_data_warning" model="mail.activity.type">
+        <field name="name">EInvoice Exception</field>
+        <field name="icon">fa-warning</field>
+        <field name="delay_count">0</field>
+        <field name="sequence">100</field>
+        <field name="decoration_type">warning</field>
+        <field name="active">False</field>
+    </record>
 </odoo>

--- a/l10n_ro_account_edi_ubl/data/mail_activity_data.xml
+++ b/l10n_ro_account_edi_ubl/data/mail_activity_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="mail_activity_einvoice_data_warning" model="mail.activity.type">
+            <field name="name">EInvoice Exception</field>
+            <field name="icon">fa-warning</field>
+            <field name="delay_count">0</field>
+            <field name="sequence">100</field>
+            <field name="decoration_type">warning</field>
+            <field name="active">False</field>
+        </record>
+    </data>
+</odoo>

--- a/l10n_ro_account_edi_ubl/models/account_edi_format.py
+++ b/l10n_ro_account_edi_ubl/models/account_edi_format.py
@@ -149,7 +149,7 @@ class AccountEdiXmlCIUSRO(models.Model):
                 )
             else:
                 invoice.activity_schedule(
-                    "mail.mail_activity_data_warning",
+                    "l10n_ro_account_edi_ubl.mail_activity_einvoice_data_warning",
                     summary=message,
                     note=body,
                     user_id=user.id,


### PR DESCRIPTION
Pentru ca erorile e-factura sa se poata primi pe mail, se poate configura o actiune automata cand se creaza o activitate de tipul mail.mail_activity_data_warning

Insa acest tip se foloseste si an alte parti (sale, purchase, stock)

Ca sa se faca distinctie, actiunea automata se poate configura cu noul tip de mail.activity
