### PR TITLE
[17.0][FIX] Refactor date handling logic in stock move methods

### DIFF
--- a/l10n_ro_stock_account_date/models/stock_move.py
+++ b/l10n_ro_stock_account_date/models/stock_move.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2022 NextERP Romania SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from datetime import date, timedelta
+from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 
@@ -16,46 +16,42 @@ class StockMove(models.Model):
     def l10n_ro_get_move_date(self):
         self.ensure_one()
         new_date = self._context.get("force_period_date")
+        now = fields.datetime.now()
         if not new_date:
             if self.picking_id:
                 if self.picking_id.l10n_ro_accounting_date:
-                    new_date = self.picking_id.l10n_ro_accounting_date.date()
+                    new_date = self.picking_id.l10n_ro_accounting_date
             elif self.is_inventory:
-                new_date = self.date.date()
+                new_date = self.date
             elif "raw_material_production_id" in self._fields:
                 if self.raw_material_production_id:
-                    new_date = self.raw_material_production_id.date_start.date()
+                    new_date = self.raw_material_production_id.date_start
                 elif self.production_id:
-                    new_date = self.production_id.date_start.date()
+                    new_date = self.production_id.date_start
             if not new_date:
-                new_date = fields.date.today()
+                new_date = now
         restrict_date_last_month = (
             self.company_id.l10n_ro_restrict_stock_move_date_last_month
         )
         restrict_date_future = self.company_id.l10n_ro_restrict_stock_move_date_future
         first_posting_date = last_posting_date = False
         if restrict_date_last_month:
-            first_posting_date = date.today().replace(day=1) + relativedelta(months=-1)
+            first_posting_date = now.replace(day=1) + relativedelta(months=-1)
             last_posting_date = (
-                date.today().replace(day=1)
-                - timedelta(days=1)
-                + relativedelta(months=1)
+                now.replace(day=1) - timedelta(days=1) + relativedelta(months=1)
             )
+
         if restrict_date_future:
-            last_posting_date = date.today()
+            last_posting_date = now
 
         if first_posting_date and last_posting_date:
             if not (first_posting_date <= new_date <= last_posting_date):
                 raise UserError(
                     _(
-                        "Cannot validate stock move due to date restriction."
-                        "The date must be between %(first_posting_date)s and "
-                        "%(last_posting_date)s"
+                        f"Cannot validate stock move due to date restriction."
+                        f" The date must be between"
+                        f" %{first_posting_date} and {last_posting_date}"
                     )
-                    % {
-                        "first_posting_date": first_posting_date,
-                        "last_posting_date": last_posting_date,
-                    }
                 )
             self.check_lock_date(self.date)
         return new_date


### PR DESCRIPTION
Simplify the handling of datetime objects by removing redundant `.date()` calls and standardizing `now` usage. Adjust error messages for readability and ensure code alignment with restrictions on stock move dates.