### PR TITLE
[17.0][FIX] Remove unused fields from stock picking form view

### DIFF
--- a/l10n_ro_stock_account/views/stock_picking_view.xml
+++ b/l10n_ro_stock_account/views/stock_picking_view.xml
@@ -5,13 +5,6 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_assign_serial']" position="before">
-                <field name="picking_code" column_invisible="1" />
-                <field
-                    name="price_unit"
-                    column_invisible="picking_code != 'incoming'"
-                />
-            </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button
                     string="Journal Items"


### PR DESCRIPTION
The fields `picking_code` and `price_unit` were removed as they were not being used in the stock picking form view. This simplifies the code and improves maintainability by eliminating unnecessary elements.