### PR TITLE
[17.0][IMP] Refactor fiscal position mapping logic.

### DIFF
--- a/l10n_ro_stock_account/models/account_move.py
+++ b/l10n_ro_stock_account/models/account_move.py
@@ -105,9 +105,9 @@ class AccountMoveLine(models.Model):
                     ai = location.l10n_ro_property_account_income_location_id
                     if ai:
                         account = ai
-            fiscal_positions |= line.move_id.journal_id.l10n_ro_fiscal_position_id
-            for fiscal_position in fiscal_positions:
-                account = fiscal_position.map_account(account or line.account_id)
+            # fiscal_positions |= line.move_id.journal_id.l10n_ro_fiscal_position_id
+            # for fiscal_position in fiscal_positions:
+            #     account = fiscal_position.map_account(account or line.account_id)
 
             if account:
                 line.account_id = account
@@ -121,3 +121,18 @@ class AccountMoveLine(models.Model):
     def _get_account_change_stock_moves_sale(self):
         sales = self.sale_line_ids.filtered(lambda s: s.move_ids)
         return sales.move_ids
+
+    def _prepare_create_values(self, vals_list):
+        result_vals_list = super()._prepare_create_values(vals_list)
+        for vals in result_vals_list:
+            move_id = vals.get("move_id", False)
+            account_id = vals.get("account_id", False)
+            if move_id and account_id:
+                move = self.env["account.move"].browse(move_id)
+                account = self.env["account.account"].browse(account_id)
+                journal = move.journal_id
+                fiscal_position = journal.l10n_ro_fiscal_position_id
+                if fiscal_position:
+                    account = fiscal_position.map_account(account)
+                    vals["account_id"] = account.id
+        return result_vals_list

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -733,21 +733,21 @@ class StockMove(models.Model):
         journal_id = self._l10n_ro_get_journal_id(
             location_from, location_to, journal_id
         )
-        # determina analiticul aferent jurnalului
-        if journal_id:
-            journal = self.env["account.journal"].browse(journal_id)
-            if journal.l10n_ro_fiscal_position_id:
-                fiscal_position = journal.l10n_ro_fiscal_position_id
-                acc_src_rec = self.env["account.account"].browse(acc_src)
-                acc_dest_rec = self.env["account.account"].browse(acc_dest)
-                acc_valuation_rec = self.env["account.account"].browse(acc_valuation)
-
-                acc_src_rec = fiscal_position.map_account(acc_src_rec)
-                acc_dest_rec = fiscal_position.map_account(acc_dest_rec)
-                acc_valuation_rec = fiscal_position.map_account(acc_valuation_rec)
-                acc_src = acc_src_rec.id
-                acc_dest = acc_dest_rec.id
-                acc_valuation = acc_valuation_rec.id
+        # # determina analiticul aferent jurnalului
+        # if journal_id:
+        #     journal = self.env["account.journal"].browse(journal_id)
+        #     if journal.l10n_ro_fiscal_position_id:
+        #         fiscal_position = journal.l10n_ro_fiscal_position_id
+        #         acc_src_rec = self.env["account.account"].browse(acc_src)
+        #         acc_dest_rec = self.env["account.account"].browse(acc_dest)
+        #         acc_valuation_rec = self.env["account.account"].browse(acc_valuation)
+        #
+        #         acc_src_rec = fiscal_position.map_account(acc_src_rec)
+        #         acc_dest_rec = fiscal_position.map_account(acc_dest_rec)
+        #         acc_valuation_rec = fiscal_position.map_account(acc_valuation_rec)
+        #         acc_src = acc_src_rec.id
+        #         acc_dest = acc_dest_rec.id
+        #         acc_valuation = acc_valuation_rec.id
 
         # self.log_account(acc_src, acc_dest, acc_valuation, journal_id)
         return journal_id, acc_src, acc_dest, acc_valuation


### PR DESCRIPTION
Comment out redundant fiscal position mapping in `account_move` and `stock_move` methods and centralize the logic in `_prepare_create_values` to improve maintainability and prevent duplicate processing.