### PR TITLE
[17.0][FIX] Update domain filters to use 'commercial_partner_id'

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -329,7 +329,7 @@ class MessageSPV(models.Model):
                     move_type = ("out_invoice", "out_refund")
 
                 domain = [
-                    ("partner_id", "=", message.partner_id.id),
+                    ("commercial_partner_id", "=", message.partner_id.id),
                     ("ref", "=", message.ref),
                     ("move_type", "in", move_type),
                 ]
@@ -409,7 +409,11 @@ class MessageSPV(models.Model):
                     ("ref", "=", new_invoice.ref),
                     ("move_type", "=", "in_invoice"),
                     ("state", "=", "posted"),
-                    ("partner_id", "=", new_invoice.partner_id.id),
+                    (
+                        "commercial_partner_id",
+                        "=",
+                        new_invoice.commercial_partner_id.id,
+                    ),
                     ("id", "!=", new_invoice.id),
                 ],
                 limit=1,


### PR DESCRIPTION
Replaced 'partner_id' with 'commercial_partner_id' in domain filters for better handling of related partner records. This ensures more accurate matching in cases involving commercial partners.