### PR TITLE
AccountMoveLine _get_computed_name fix 

### DIFF
--- a/l10n_ro_account_edi_ubl/models/account_edi_format.py
+++ b/l10n_ro_account_edi_ubl/models/account_edi_format.py
@@ -34,6 +34,14 @@ class AccountEdiXmlCIUSRO(models.Model):
                 if old_attachment:
                     edi_document.attachment_id = False
                     old_attachment.unlink()
+                domain = [
+                    ("res_model", "=", "account.move"),
+                    ("res_id", "=", invoice.id),
+                    ("name", "=", xml_name),
+                ]
+                old_attachment = self.env["ir.attachment"].sudo().search(domain)
+                if old_attachment:
+                    old_attachment.unlink()
                 res = self.env["ir.attachment"].create(
                     {
                         "name": xml_name,

--- a/l10n_ro_account_edi_ubl/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_account_edi_ubl/models/account_edi_xml_cius_ro.py
@@ -383,15 +383,21 @@ class AccountEdiXmlCIUSRO(models.Model):
     def _import_fill_invoice_line_form(
         self, journal, tree, invoice_form, invoice_line_form, qty_factor
     ):
+
+        def _find_value(xpath, element=tree):
+            # avoid 'TypeError: empty namespace prefix is not supported in XPath'
+            nsmap = {k: v for k, v in tree.nsmap.items() if k is not None}
+            return self.env["account.edi.format"]._find_value(xpath, element, nsmap)
+
         res = super()._import_fill_invoice_line_form(
             journal, tree, invoice_form, invoice_line_form, qty_factor
         )
 
-        vendor_code = self._find_value(
+        vendor_code = _find_value(
             "./cac:Item/cac:SellersItemIdentification/cbc:ID", tree
         )
         if not vendor_code:
-            vendor_code = self._find_value(
+            vendor_code = _find_value(
                 "./cac:Item/cac:StandardItemIdentification/cbc:ID", tree
             )
 

--- a/l10n_ro_account_edi_ubl/models/account_edi_xml_cius_ro.py
+++ b/l10n_ro_account_edi_ubl/models/account_edi_xml_cius_ro.py
@@ -383,7 +383,6 @@ class AccountEdiXmlCIUSRO(models.Model):
     def _import_fill_invoice_line_form(
         self, journal, tree, invoice_form, invoice_line_form, qty_factor
     ):
-
         def _find_value(xpath, element=tree):
             # avoid 'TypeError: empty namespace prefix is not supported in XPath'
             nsmap = {k: v for k, v in tree.nsmap.items() if k is not None}

--- a/l10n_ro_account_edi_ubl/models/account_move.py
+++ b/l10n_ro_account_edi_ubl/models/account_move.py
@@ -425,6 +425,7 @@ class AccountMoveLine(models.Model):
         if (
             self.move_id.move_type not in ["in_invoice", "in_refund"]
             or not self.move_id.l10n_ro_edi_download
+            or not self.name
         ):
             return super()._get_computed_name()
         else:


### PR DESCRIPTION
- return standard functionality when name is empty

There is an overwrite on _get_computed_name, to not delete the name/label when it comes from e-invoice or is incoming invoice. Added a third condition - when the field is empty, the standard functionality should work, because the is nothing to delete.

We have clients that delete rows/rewrite rows entirely when identifying products on e-invoices, and then the name field is not filled - that causes problems by example to the deltatech_invoice_receipt module, where it cannot create the related Purchase Order because of the missing name field.