### PR TITLE
[17.0][IMP] Actualizează câmpurile orașului la selecție automată.

### DIFF
--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -46,7 +46,13 @@ class Partner(models.Model):
                 city = self.env["res.city"].search(domain, limit=1)
 
             if city:
-                self.city_id = city
+                self.write(
+                    {
+                        "city_id": city.id,
+                        "city": city.name,
+                        "state_id": city.state_id.id,
+                    }
+                )
 
     @api.onchange("city_id")
     def _onchange_city_id(self):


### PR DESCRIPTION
Modificarea asigură actualizarea câmpurilor "city", "city_id" și "state_id" atunci când orașul este setat automat. Aceasta îmbunătățește consistența datelor și elimină riscul de nealiniere între câmpurile legate de oraș.