### PR TITLE
[17.0][IMP] Adaugă crearea automată a documentelor EDI pentru facturi

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -391,6 +391,14 @@ class MessageSPV(models.Model):
                     {"res_id": message.invoice_id.id, "res_model": "account.move"}
                 )
 
+        if "out" in message.message_type:
+            if not message.invoice_id.l10n_ro_edi_document_ids:
+                self.env["l10n_ro_edi.document"].create({
+                    "invoice_id": message.invoice_id.id,
+                    'state': 'invoice_sending',
+                    'key_loading': message.request_id,
+                })
+
     def create_invoice(self):
         self.get_partner()
         for message in self.filtered(lambda m: not m.invoice_id):

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -393,11 +393,13 @@ class MessageSPV(models.Model):
 
         if "out" in message.message_type:
             if not message.invoice_id.l10n_ro_edi_document_ids:
-                self.env["l10n_ro_edi.document"].create({
-                    "invoice_id": message.invoice_id.id,
-                    'state': 'invoice_sending',
-                    'key_loading': message.request_id,
-                })
+                self.env["l10n_ro_edi.document"].create(
+                    {
+                        "invoice_id": message.invoice_id.id,
+                        "state": "invoice_sending",
+                        "key_loading": message.request_id,
+                    }
+                )
 
     def create_invoice(self):
         self.get_partner()


### PR DESCRIPTION
În cazul mesajelor de tip "out", se verifică dacă factura asociată nu are documente EDI existente. Dacă nu există, se creează un document EDI cu starea "invoice_sending" și se asociază la factură. Acest lucru automatizează procesul și asigură trimiterea corectă a facturilor.