### PR TITLE
[17.0][IMP] Adaugă creare document EDI pentru facturi fără documente existente

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -401,6 +401,19 @@ class MessageSPV(models.Model):
                                 "key_loading": message.request_id,
                             }
                         )
+                if not message.invoice_id.l10n_ro_edi_document_ids:
+                    if message.message_type != "error":
+                        state = "invoice_sent"
+                    else:
+                        state = "invoice_sending_failed"
+
+                    self.env["l10n_ro_edi.document"].create(
+                        {
+                            "invoice_id": message.invoice_id.id,
+                            "state": state,
+                            "key_loading": message.request_id,
+                        }
+                    )
 
     def create_invoice(self):
         self.get_partner()

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -113,7 +113,8 @@ class ResCompany(models.Model):
                             "state": "draft",
                         }
                     )
+                    spv_message.download_from_spv()
                     if spv_message.message_type in ["error", "message"]:
                         spv_message.get_invoice_from_move()
-                        spv_message.download_from_spv()
+
         return True

--- a/l10n_ro_message_spv/views/message_spv_view.xml
+++ b/l10n_ro_message_spv/views/message_spv_view.xml
@@ -77,7 +77,7 @@
                         name="create_invoice"
                         string="Create Invoice"
                         type="object"
-                        invisible="message_type != 'in_invoice'"
+                        invisible="message_type not in ('in_invoice','in_receipt')"
                     />
 
                     <button name="render_anaf_pdf" string="Render PDF" type="object" />


### PR DESCRIPTION
Se creează un document EDI în funcție de starea mesajului SPV în cazurile în care factura nu are deja documente asociate. De asemenea, s-a ajustat logica de descărcare a mesajelor SPV pentru a fi procesate înainte de asocierea facturii.