### PR TITLE
[17.0][IMP] Activează maparea conturilor fiscale în stock_move

### DIFF
--- a/l10n_ro_stock_account/models/__init__.py
+++ b/l10n_ro_stock_account/models/__init__.py
@@ -2,6 +2,7 @@ from . import account_account
 from . import account_move
 from . import product_category
 from . import product_template
+from . import product_product
 from . import res_company
 from . import stock_location
 from . import stock_move

--- a/l10n_ro_stock_account/models/product_product.py
+++ b/l10n_ro_stock_account/models/product_product.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2014 Forest and Biomass Romania
+# Copyright (C) 2020 NextERP Romania
+# Copyright (C) 2020 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class ProductProduct(models.Model):
+    _name = "product.product"
+    _inherit = ["product.product", "l10n.ro.mixin"]
+
+    def _get_fifo_candidates_domain(self, company):
+        domain = super()._get_fifo_candidates_domain(company=company)
+        l10n_ro_account_ids = self.env.context.get("l10n_ro_account_ids")
+        if l10n_ro_account_ids:
+            domain.append(("l10n_ro_account_id", "in", l10n_ro_account_ids))
+        return domain

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -733,21 +733,21 @@ class StockMove(models.Model):
         journal_id = self._l10n_ro_get_journal_id(
             location_from, location_to, journal_id
         )
-        # # determina analiticul aferent jurnalului
-        # if journal_id:
-        #     journal = self.env["account.journal"].browse(journal_id)
-        #     if journal.l10n_ro_fiscal_position_id:
-        #         fiscal_position = journal.l10n_ro_fiscal_position_id
-        #         acc_src_rec = self.env["account.account"].browse(acc_src)
-        #         acc_dest_rec = self.env["account.account"].browse(acc_dest)
-        #         acc_valuation_rec = self.env["account.account"].browse(acc_valuation)
-        #
-        #         acc_src_rec = fiscal_position.map_account(acc_src_rec)
-        #         acc_dest_rec = fiscal_position.map_account(acc_dest_rec)
-        #         acc_valuation_rec = fiscal_position.map_account(acc_valuation_rec)
-        #         acc_src = acc_src_rec.id
-        #         acc_dest = acc_dest_rec.id
-        #         acc_valuation = acc_valuation_rec.id
+        # determina analiticul aferent jurnalului
+        if journal_id:
+            journal = self.env["account.journal"].browse(journal_id)
+            if journal.l10n_ro_fiscal_position_id:
+                fiscal_position = journal.l10n_ro_fiscal_position_id
+                acc_src_rec = self.env["account.account"].browse(acc_src)
+                acc_dest_rec = self.env["account.account"].browse(acc_dest)
+                acc_valuation_rec = self.env["account.account"].browse(acc_valuation)
+
+                acc_src_rec = fiscal_position.map_account(acc_src_rec)
+                acc_dest_rec = fiscal_position.map_account(acc_dest_rec)
+                acc_valuation_rec = fiscal_position.map_account(acc_valuation_rec)
+                acc_src = acc_src_rec.id
+                acc_dest = acc_dest_rec.id
+                acc_valuation = acc_valuation_rec.id
 
         # self.log_account(acc_src, acc_dest, acc_valuation, journal_id)
         return journal_id, acc_src, acc_dest, acc_valuation
@@ -817,7 +817,7 @@ class StockMove(models.Model):
         if self.product_id.cost_method != "average":
             return price_unit
 
-        if self._is_in:
+        if self._is_in():
             if self.price_unit:
                 return self.price_unit
         elif not self._is_out():

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -890,3 +890,20 @@ class StockMove(models.Model):
                     _logger.debug(svl_value)
 
         return svl_values
+
+    def _action_done(self, cancel_backorder=False):
+        accounts = []
+        for move in self:
+            (
+                journal_id,
+                acc_src,
+                acc_dest,
+                acc_valuation,
+            ) = move._get_accounting_data_for_valuation()
+            accounts += [acc_src, acc_dest, acc_valuation]
+
+        if accounts:
+            accounts = list(set(accounts))
+            self = self.with_context(l10n_ro_account_ids=accounts)
+        res = super()._action_done(cancel_backorder=cancel_backorder)
+        return res

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -118,3 +118,22 @@ class StockValuationLayer(models.Model):
             account_moves._post()
 
         return res
+
+    @api.model
+    def _read_group(
+        self,
+        domain,
+        groupby=(),
+        aggregates=(),
+        having=(),
+        offset=0,
+        limit=None,
+        order=None,
+    ):
+        l10n_ro_account_ids = self.env.context.get("l10n_ro_account_ids")
+        if l10n_ro_account_ids:
+            domain.append(("l10n_ro_account_id", "in", l10n_ro_account_ids))
+
+        return super()._read_group(
+            domain, groupby, aggregates, having, offset, limit, order
+        )


### PR DESCRIPTION
Elimină comentariile și reactivează logica de mapare a conturilor fiscale în funcție de poziția fiscală. De asemenea, corectează apelul metodei `_is_in` pentru a include parantezele lipsă.