### PR TITLE
[18.0][IMP] Elimină câmpul `is_l10n_ro_record` din resursele XML

### DIFF
--- a/l10n_ro_config/i18n/bg.po
+++ b/l10n_ro_config/i18n/bg.po
@@ -1,0 +1,1016 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-02 07:40+0000\n"
+"PO-Revision-Date: 2025-04-02 07:40+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Account:</strong>"
+msgstr "<strong>Сметка:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Address:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Bank:</strong>"
+msgstr "<strong>Банка:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Company</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>NRC:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Share Capital:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "ANAF Integration"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "Account ANAF Sync"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a mechanism to close Incomes, Expense, VAT on a period base."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a stock sheet report for products grouped by Location, Account."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add a vat on payment field in partners, change the fiscal position with the "
+"one defined in settings depending on the partner and invoice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add company field for no signature, update invoice report for multi "
+"currency."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add predefined layouts to stock reports."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add valued reports for stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Adds location in_custody, usage_giving, consume *merchandise_type: store, "
+"warehouse."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__use_anglo_saxon
+msgid "Anglo-Saxon Accounting"
+msgstr "Англо-саксонско Счетоводство"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Банкови Сметки"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_company
+msgid "Companies"
+msgstr "Фирми"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Complete also staircase in extended address for partners."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_config_settings
+msgid "Config Settings"
+msgstr "Настройки"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner
+msgid "Contact"
+msgstr "Контакт"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid "Create Partners by VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Create partners based on the vat code from ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid "Currency Rate Update BNR"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Currency rate in invoice is editable, so you can use your own currency rate."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv1
+msgid "Customer Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default Services Taxes"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default taxes applied to local transactions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Extend the  partner addres field with flat number, staircase.."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_receipt
+msgid "Fiscal Receipts Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"If this field is checked and the company use Romanian Accounting, the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule; If this field is NOT checked and the "
+"company use Romanian Accounting, the value used for stock out operations "
+"will be the value provided by FIFO rule, applied strictly on a location "
+"level (including its children)."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the "
+"currency rate differences between reception and invoice will be reflected in"
+" the stock valuation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule;If this field is NOT checked and the "
+"company use Romanian Accounting,the value used for stock out operations will"
+" be the value provided by FIFO rule, applied strictly on a location level "
+"(including its children)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Install BNR update rates"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__normal
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "Invoice Edit Currency Rate"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "Invoice Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_ir_ui_menu__is_l10n_ro_record
+msgid "Is L10N Ro Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_l10n_ro_mixin__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__is_l10n_ro_record
+msgid "Is Romanian Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_account_journal
+msgid "Journal"
+msgstr "Дневник"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation_visible
+msgid "L10N Ro Stock Account Svl Lot Allocation Visible"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Mark stock operations as notice operations. Stock accounting will change to "
+"use and accounts."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_ir_ui_menu
+msgid "Menu"
+msgstr "Меню"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_l10n_ro_mixin
+msgid "Mixin model for applying to any object that use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "Notification !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Partners & Addresses"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid "Partners Fiscal Validation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "Partners unique by Company, VAT, NRC"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Print custom receipt report for Romanian companies."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_print_report
+msgid "Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_product_template
+msgid "Product"
+msgstr "Продукт"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record DVI directly from invoices."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record cost of goods sold in your journal entries."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record price differences between bills and reception through Landed Cost"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record the payment directly to bank or cash statement. Set up different "
+"sequences for cash operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register non deductible VAT in accounting and stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register sync oAuth with ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Registration of accounting moves according to Romanian legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+msgid "Restrict Stock Move Date Future"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict Stock Move Date Last Month"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting in the last month."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict stock move posting with at most one month ago."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting with future date."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.view_account_bank_journal_form
+msgid "Ro Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_partner_id
+msgid "Romania - Autoinvoice Partner"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_sequence_type
+msgid "Romania - Autoinvoice Sequence Type"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_caen_code
+msgid "Romania - CAEN Code"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid "Romania - Company Stock Transfer Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid "Romania - Customs Commission Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid "Romania - Customs Duty Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_purchase_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_purchase_tax_id
+msgid "Romania - Default Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_sale_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_sale_tax_id
+msgid "Romania - Default Services Sale Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_e_invoice
+msgid "Romania - E-Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_position_id
+msgid "Romania - Fiscal Position"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_inverse_taxation_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_inverse_taxation_position_id
+msgid "Romania - Fiscal Position for Inverse Taxation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_vat_on_payment_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_vat_on_payment_position_id
+msgid "Romania - Fiscal Position for VAT on Payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid "Romania - Non Deductible Expense Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid "Romania - Not Eligible Tax Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid "Romania - Picking Account Custody"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid "Romania - Picking Account Payable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid "Romania - Picking Account Receivable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid "Romania - Price Difference Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__l10n_ro_print_report
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__l10n_ro_print_report
+msgid "Romania - Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_share_capital
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_share_capital
+msgid "Romania - Share Capital"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid "Romania - Stock Accounting Valuation Lot/Serial allocation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid "Romania - Stock Valuation Update"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_granted_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_granted_account_id
+msgid "Romania - Trade discounts granted"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_received_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_received_account_id
+msgid "Romania - Trade discounts received"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid "Romania - Usage Giving Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_accounting
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_accounting
+msgid "Romania - Use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_subjected
+msgid "Romania - VAT Subjected"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "Romania - VAT number digits"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid "Romania Account Period Close"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:res.groups,name:l10n_ro_config.group_ro_menus
+msgid "Romania Menus"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_nondeductible_vat
+msgid "Romania Non Deductible VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_receipt_report
+msgid "Romania Payment Receipt Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_to_statement
+msgid "Romania Payment to Statement"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid "Romanian Cities"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_dvi
+msgid "Romanian DVI"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Romanian Extended Address"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid "Romanian SIRUTA"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid "Romanian Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_notice
+msgid "Romanian Stock Account Notice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid "Romanian Stock Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "Romanian Stock Accounting Date"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid "Romanian Stock Accounting Date Wizard"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid "Romanian Stock Accounting Price Difference"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_comment_template
+msgid "Romanian Stock Picking Comment Template"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_valued_report
+msgid "Romanian Stock Picking Valued Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_report
+msgid "Romanian Stock Sheet Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "România"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 408"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 418"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 482"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 8035"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select Accounting Date in stock operations wizard."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select Accounting Date in stock operations. All transactions will have the "
+"Accounting Date as the used date in stock."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a expense account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs commission "
+"registration in landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs duty registration in "
+"landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in landed cost to register price "
+"differences.<br/>An expense account needs to be set on product or product "
+"category."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select also the commune and zone in partner addresses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Sales Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Set up a rule for unique partners based on vat, nrc and company."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv2
+msgid "Supplier  Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "The values used for stock out operations will not follow FIFO rule!"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid ""
+"This account will be used as an intermediary account for account move line "
+"generated from internal moves between company stores."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"This account will be used as the default non deductible expense account from"
+"                                 tax repartition lines marked as not "
+"deductible. If the line account does not                                 "
+"have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid ""
+"This account will be used as the default non deductible expense account from"
+" tax repartition lines marked as not deductible. If the line account does "
+"not have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid ""
+"This account will be used as the extra trial balance payable account for the"
+" current partner on stock picking received in custody."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid ""
+"This account will be used as the not eligible tax account for account move line.\n"
+"Used in especially in inventory losses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid ""
+"This account will be used as the payable account for the current partner on "
+"stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid ""
+"This account will be used as the receivable account for the current partner "
+"on stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid ""
+"This account will be used as the usage giving account in account move line."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid ""
+"This allows you to close accounts on periods based on templates: Income, "
+"Expense, VAT..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid ""
+"This allows you to create partners based on VAT:\n"
+"Romanian partners will be create based on ANAF webservice.\n"
+"European partners will be create based on VIES webservice (for countries that allow). \n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid ""
+"This allows you to manage price differences between receptions and invoices.\n"
+"It will be done by using landed cost, to also threat deliveries between reception and supplier invoice confirmation.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid ""
+"This allows you to manage the Romanian Cities:\n"
+" The address fields will contain city, municipality, siruta."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid ""
+"This allows you to manage the Romanian Stock Accounting, for locations with warehouse merchandise, including:\n"
+"New stock accounts on location to allow moving entry in accounting based on the stock move.\n"
+"The account entry will be generated from stock move instead of stock quant, link with the generated account move lines on the picking\n"
+"Inventory account move lines..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid ""
+"This allows you to manage the Romanian Zones, Communes\n"
+" The address fields will contain new many2one to communes and zones."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid ""
+"This allows you to manage the vat subjected and vat on payment fields update:\n"
+"For Romanian partners based on ANAF webservice.\n"
+"For European partners based on VIES data."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "This allows you to print invoice report based on romanian layout.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "This allows you to set unique partners by company, VAT and NRC."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "This allows you to set up the Accounting Date on stock operation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid ""
+"This allows you to set up the Accounting Date on stock operation.The "
+"Accounting Date will be showed up in confirmation wizards."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "This allows you to the currency rate in invoices.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid ""
+"This module add on each warehouse methods of usage giving and consumption"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid ""
+"This module will download data from ANAF site and when you give or receive a"
+" invoice will set fiscal position for VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "This option allows you to manage the sync to ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid ""
+"This option allows you to manage the update of currency rate based from BNR "
+"site."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty "
+"commissions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid ""
+"This product will be used to create the landed costfor the price difference "
+"between picking and bill"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid ""
+"Tracking (Lot/Serial) has to be enabled first for all stockable and "
+"consumable products !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update partners data based on the vat code from ANAF website in cron job."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update stock valuation in case of price difference between reception and "
+"bill."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Updates stock accounting according to Romanian Legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Upload Romanian cities, so you can select them more easily."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__anglo_saxon_accounting
+msgid "Use anglo-saxon accounting"
+msgstr "Използвайте англосаксонско счетоводство"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "VAT number without country code."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid "VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid ""
+"Will update daily from cron only if is checked Automatic Currency Rates "
+"(OCA) and you added a rate_provider."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "cont stock marfa primita in custodie (creeat nou extrabilantier)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"use 4428 cont pentru tva neexigibil in notele facute pentru 'Marfa in "
+"magazin'"
+msgstr ""

--- a/l10n_ro_config/i18n/de.po
+++ b/l10n_ro_config/i18n/de.po
@@ -1,0 +1,1016 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-02 07:43+0000\n"
+"PO-Revision-Date: 2025-04-02 07:43+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Account:</strong>"
+msgstr "<strong>Konto:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Address:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Bank:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Company</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>NRC:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Share Capital:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "ANAF Integration"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "Account ANAF Sync"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a mechanism to close Incomes, Expense, VAT on a period base."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a stock sheet report for products grouped by Location, Account."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add a vat on payment field in partners, change the fiscal position with the "
+"one defined in settings depending on the partner and invoice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add company field for no signature, update invoice report for multi "
+"currency."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add predefined layouts to stock reports."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add valued reports for stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Adds location in_custody, usage_giving, consume *merchandise_type: store, "
+"warehouse."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__use_anglo_saxon
+msgid "Anglo-Saxon Accounting"
+msgstr "Angelsächsische Buchhaltung"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Bankkonten"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_company
+msgid "Companies"
+msgstr "Unternehmen"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Complete also staircase in extended address for partners."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_config_settings
+msgid "Config Settings"
+msgstr "Konfigurationseinstellungen "
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner
+msgid "Contact"
+msgstr "Kontakt"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid "Create Partners by VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Create partners based on the vat code from ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid "Currency Rate Update BNR"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Currency rate in invoice is editable, so you can use your own currency rate."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv1
+msgid "Customer Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default Services Taxes"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default taxes applied to local transactions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Extend the  partner addres field with flat number, staircase.."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_receipt
+msgid "Fiscal Receipts Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"If this field is checked and the company use Romanian Accounting, the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule; If this field is NOT checked and the "
+"company use Romanian Accounting, the value used for stock out operations "
+"will be the value provided by FIFO rule, applied strictly on a location "
+"level (including its children)."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the "
+"currency rate differences between reception and invoice will be reflected in"
+" the stock valuation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule;If this field is NOT checked and the "
+"company use Romanian Accounting,the value used for stock out operations will"
+" be the value provided by FIFO rule, applied strictly on a location level "
+"(including its children)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Install BNR update rates"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__normal
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "Invoice Edit Currency Rate"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "Invoice Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_ir_ui_menu__is_l10n_ro_record
+msgid "Is L10N Ro Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_l10n_ro_mixin__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__is_l10n_ro_record
+msgid "Is Romanian Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation_visible
+msgid "L10N Ro Stock Account Svl Lot Allocation Visible"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Mark stock operations as notice operations. Stock accounting will change to "
+"use and accounts."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_ir_ui_menu
+msgid "Menu"
+msgstr "Menü"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_l10n_ro_mixin
+msgid "Mixin model for applying to any object that use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "Notification !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Partners & Addresses"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid "Partners Fiscal Validation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "Partners unique by Company, VAT, NRC"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Print custom receipt report for Romanian companies."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_print_report
+msgid "Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_product_template
+msgid "Product"
+msgstr "Produkt"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record DVI directly from invoices."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record cost of goods sold in your journal entries."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record price differences between bills and reception through Landed Cost"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record the payment directly to bank or cash statement. Set up different "
+"sequences for cash operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register non deductible VAT in accounting and stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register sync oAuth with ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Registration of accounting moves according to Romanian legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+msgid "Restrict Stock Move Date Future"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict Stock Move Date Last Month"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting in the last month."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict stock move posting with at most one month ago."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting with future date."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.view_account_bank_journal_form
+msgid "Ro Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_partner_id
+msgid "Romania - Autoinvoice Partner"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_sequence_type
+msgid "Romania - Autoinvoice Sequence Type"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_caen_code
+msgid "Romania - CAEN Code"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid "Romania - Company Stock Transfer Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid "Romania - Customs Commission Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid "Romania - Customs Duty Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_purchase_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_purchase_tax_id
+msgid "Romania - Default Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_sale_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_sale_tax_id
+msgid "Romania - Default Services Sale Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_e_invoice
+msgid "Romania - E-Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_position_id
+msgid "Romania - Fiscal Position"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_inverse_taxation_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_inverse_taxation_position_id
+msgid "Romania - Fiscal Position for Inverse Taxation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_vat_on_payment_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_vat_on_payment_position_id
+msgid "Romania - Fiscal Position for VAT on Payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid "Romania - Non Deductible Expense Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid "Romania - Not Eligible Tax Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid "Romania - Picking Account Custody"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid "Romania - Picking Account Payable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid "Romania - Picking Account Receivable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid "Romania - Price Difference Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__l10n_ro_print_report
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__l10n_ro_print_report
+msgid "Romania - Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_share_capital
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_share_capital
+msgid "Romania - Share Capital"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid "Romania - Stock Accounting Valuation Lot/Serial allocation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid "Romania - Stock Valuation Update"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_granted_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_granted_account_id
+msgid "Romania - Trade discounts granted"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_received_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_received_account_id
+msgid "Romania - Trade discounts received"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid "Romania - Usage Giving Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_accounting
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_accounting
+msgid "Romania - Use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_subjected
+msgid "Romania - VAT Subjected"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "Romania - VAT number digits"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid "Romania Account Period Close"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:res.groups,name:l10n_ro_config.group_ro_menus
+msgid "Romania Menus"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_nondeductible_vat
+msgid "Romania Non Deductible VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_receipt_report
+msgid "Romania Payment Receipt Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_to_statement
+msgid "Romania Payment to Statement"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid "Romanian Cities"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_dvi
+msgid "Romanian DVI"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Romanian Extended Address"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid "Romanian SIRUTA"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid "Romanian Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_notice
+msgid "Romanian Stock Account Notice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid "Romanian Stock Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "Romanian Stock Accounting Date"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid "Romanian Stock Accounting Date Wizard"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid "Romanian Stock Accounting Price Difference"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_comment_template
+msgid "Romanian Stock Picking Comment Template"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_valued_report
+msgid "Romanian Stock Picking Valued Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_report
+msgid "Romanian Stock Sheet Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "România"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 408"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 418"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 482"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 8035"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select Accounting Date in stock operations wizard."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select Accounting Date in stock operations. All transactions will have the "
+"Accounting Date as the used date in stock."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a expense account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs commission "
+"registration in landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs duty registration in "
+"landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in landed cost to register price "
+"differences.<br/>An expense account needs to be set on product or product "
+"category."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select also the commune and zone in partner addresses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Sales Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Set up a rule for unique partners based on vat, nrc and company."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv2
+msgid "Supplier  Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "The values used for stock out operations will not follow FIFO rule!"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid ""
+"This account will be used as an intermediary account for account move line "
+"generated from internal moves between company stores."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"This account will be used as the default non deductible expense account from"
+"                                 tax repartition lines marked as not "
+"deductible. If the line account does not                                 "
+"have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid ""
+"This account will be used as the default non deductible expense account from"
+" tax repartition lines marked as not deductible. If the line account does "
+"not have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid ""
+"This account will be used as the extra trial balance payable account for the"
+" current partner on stock picking received in custody."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid ""
+"This account will be used as the not eligible tax account for account move line.\n"
+"Used in especially in inventory losses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid ""
+"This account will be used as the payable account for the current partner on "
+"stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid ""
+"This account will be used as the receivable account for the current partner "
+"on stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid ""
+"This account will be used as the usage giving account in account move line."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid ""
+"This allows you to close accounts on periods based on templates: Income, "
+"Expense, VAT..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid ""
+"This allows you to create partners based on VAT:\n"
+"Romanian partners will be create based on ANAF webservice.\n"
+"European partners will be create based on VIES webservice (for countries that allow). \n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid ""
+"This allows you to manage price differences between receptions and invoices.\n"
+"It will be done by using landed cost, to also threat deliveries between reception and supplier invoice confirmation.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid ""
+"This allows you to manage the Romanian Cities:\n"
+" The address fields will contain city, municipality, siruta."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid ""
+"This allows you to manage the Romanian Stock Accounting, for locations with warehouse merchandise, including:\n"
+"New stock accounts on location to allow moving entry in accounting based on the stock move.\n"
+"The account entry will be generated from stock move instead of stock quant, link with the generated account move lines on the picking\n"
+"Inventory account move lines..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid ""
+"This allows you to manage the Romanian Zones, Communes\n"
+" The address fields will contain new many2one to communes and zones."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid ""
+"This allows you to manage the vat subjected and vat on payment fields update:\n"
+"For Romanian partners based on ANAF webservice.\n"
+"For European partners based on VIES data."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "This allows you to print invoice report based on romanian layout.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "This allows you to set unique partners by company, VAT and NRC."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "This allows you to set up the Accounting Date on stock operation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid ""
+"This allows you to set up the Accounting Date on stock operation.The "
+"Accounting Date will be showed up in confirmation wizards."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "This allows you to the currency rate in invoices.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid ""
+"This module add on each warehouse methods of usage giving and consumption"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid ""
+"This module will download data from ANAF site and when you give or receive a"
+" invoice will set fiscal position for VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "This option allows you to manage the sync to ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid ""
+"This option allows you to manage the update of currency rate based from BNR "
+"site."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty "
+"commissions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid ""
+"This product will be used to create the landed costfor the price difference "
+"between picking and bill"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid ""
+"Tracking (Lot/Serial) has to be enabled first for all stockable and "
+"consumable products !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update partners data based on the vat code from ANAF website in cron job."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update stock valuation in case of price difference between reception and "
+"bill."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Updates stock accounting according to Romanian Legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Upload Romanian cities, so you can select them more easily."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__anglo_saxon_accounting
+msgid "Use anglo-saxon accounting"
+msgstr "Angelsächsische Buchhaltung verwenden"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "VAT number without country code."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid "VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid ""
+"Will update daily from cron only if is checked Automatic Currency Rates "
+"(OCA) and you added a rate_provider."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "cont stock marfa primita in custodie (creeat nou extrabilantier)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"use 4428 cont pentru tva neexigibil in notele facute pentru 'Marfa in "
+"magazin'"
+msgstr ""

--- a/l10n_ro_config/i18n/el_GR.po
+++ b/l10n_ro_config/i18n/el_GR.po
@@ -1,0 +1,1016 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-02 07:44+0000\n"
+"PO-Revision-Date: 2025-04-02 07:44+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Account:</strong>"
+msgstr "<strong>Λογαριασμός:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Address:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Bank:</strong>"
+msgstr "<strong>Τράπεζα:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Company</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>NRC:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Share Capital:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "ANAF Integration"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "Account ANAF Sync"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a mechanism to close Incomes, Expense, VAT on a period base."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a stock sheet report for products grouped by Location, Account."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add a vat on payment field in partners, change the fiscal position with the "
+"one defined in settings depending on the partner and invoice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add company field for no signature, update invoice report for multi "
+"currency."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add predefined layouts to stock reports."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add valued reports for stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Adds location in_custody, usage_giving, consume *merchandise_type: store, "
+"warehouse."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__use_anglo_saxon
+msgid "Anglo-Saxon Accounting"
+msgstr "Αγγλοσαξονική Λογιστική"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Τραπεζικοί Λογαριασμοί"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_company
+msgid "Companies"
+msgstr "Εταιρίες"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Complete also staircase in extended address for partners."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ρυθμίσεις διαμόρφωσης"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner
+msgid "Contact"
+msgstr "Επαφή"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid "Create Partners by VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Create partners based on the vat code from ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid "Currency Rate Update BNR"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Currency rate in invoice is editable, so you can use your own currency rate."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv1
+msgid "Customer Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default Services Taxes"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default taxes applied to local transactions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Extend the  partner addres field with flat number, staircase.."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_receipt
+msgid "Fiscal Receipts Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"If this field is checked and the company use Romanian Accounting, the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule; If this field is NOT checked and the "
+"company use Romanian Accounting, the value used for stock out operations "
+"will be the value provided by FIFO rule, applied strictly on a location "
+"level (including its children)."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the "
+"currency rate differences between reception and invoice will be reflected in"
+" the stock valuation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule;If this field is NOT checked and the "
+"company use Romanian Accounting,the value used for stock out operations will"
+" be the value provided by FIFO rule, applied strictly on a location level "
+"(including its children)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Install BNR update rates"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__normal
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "Invoice Edit Currency Rate"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "Invoice Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_ir_ui_menu__is_l10n_ro_record
+msgid "Is L10N Ro Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_l10n_ro_mixin__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__is_l10n_ro_record
+msgid "Is Romanian Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_account_journal
+msgid "Journal"
+msgstr "Ημερολόγιο"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation_visible
+msgid "L10N Ro Stock Account Svl Lot Allocation Visible"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Mark stock operations as notice operations. Stock accounting will change to "
+"use and accounts."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_ir_ui_menu
+msgid "Menu"
+msgstr "Μενού"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_l10n_ro_mixin
+msgid "Mixin model for applying to any object that use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "Notification !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Partners & Addresses"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid "Partners Fiscal Validation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "Partners unique by Company, VAT, NRC"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Print custom receipt report for Romanian companies."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_print_report
+msgid "Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_product_template
+msgid "Product"
+msgstr "Είδος"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record DVI directly from invoices."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record cost of goods sold in your journal entries."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record price differences between bills and reception through Landed Cost"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record the payment directly to bank or cash statement. Set up different "
+"sequences for cash operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register non deductible VAT in accounting and stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register sync oAuth with ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Registration of accounting moves according to Romanian legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+msgid "Restrict Stock Move Date Future"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict Stock Move Date Last Month"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting in the last month."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict stock move posting with at most one month ago."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting with future date."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.view_account_bank_journal_form
+msgid "Ro Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_partner_id
+msgid "Romania - Autoinvoice Partner"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_sequence_type
+msgid "Romania - Autoinvoice Sequence Type"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_caen_code
+msgid "Romania - CAEN Code"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid "Romania - Company Stock Transfer Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid "Romania - Customs Commission Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid "Romania - Customs Duty Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_purchase_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_purchase_tax_id
+msgid "Romania - Default Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_sale_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_sale_tax_id
+msgid "Romania - Default Services Sale Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_e_invoice
+msgid "Romania - E-Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_position_id
+msgid "Romania - Fiscal Position"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_inverse_taxation_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_inverse_taxation_position_id
+msgid "Romania - Fiscal Position for Inverse Taxation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_vat_on_payment_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_vat_on_payment_position_id
+msgid "Romania - Fiscal Position for VAT on Payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid "Romania - Non Deductible Expense Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid "Romania - Not Eligible Tax Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid "Romania - Picking Account Custody"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid "Romania - Picking Account Payable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid "Romania - Picking Account Receivable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid "Romania - Price Difference Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__l10n_ro_print_report
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__l10n_ro_print_report
+msgid "Romania - Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_share_capital
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_share_capital
+msgid "Romania - Share Capital"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid "Romania - Stock Accounting Valuation Lot/Serial allocation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid "Romania - Stock Valuation Update"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_granted_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_granted_account_id
+msgid "Romania - Trade discounts granted"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_received_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_received_account_id
+msgid "Romania - Trade discounts received"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid "Romania - Usage Giving Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_accounting
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_accounting
+msgid "Romania - Use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_subjected
+msgid "Romania - VAT Subjected"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "Romania - VAT number digits"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid "Romania Account Period Close"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:res.groups,name:l10n_ro_config.group_ro_menus
+msgid "Romania Menus"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_nondeductible_vat
+msgid "Romania Non Deductible VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_receipt_report
+msgid "Romania Payment Receipt Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_to_statement
+msgid "Romania Payment to Statement"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid "Romanian Cities"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_dvi
+msgid "Romanian DVI"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Romanian Extended Address"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid "Romanian SIRUTA"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid "Romanian Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_notice
+msgid "Romanian Stock Account Notice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid "Romanian Stock Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "Romanian Stock Accounting Date"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid "Romanian Stock Accounting Date Wizard"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid "Romanian Stock Accounting Price Difference"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_comment_template
+msgid "Romanian Stock Picking Comment Template"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_valued_report
+msgid "Romanian Stock Picking Valued Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_report
+msgid "Romanian Stock Sheet Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "România"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 408"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 418"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 482"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 8035"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select Accounting Date in stock operations wizard."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select Accounting Date in stock operations. All transactions will have the "
+"Accounting Date as the used date in stock."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a expense account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs commission "
+"registration in landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs duty registration in "
+"landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in landed cost to register price "
+"differences.<br/>An expense account needs to be set on product or product "
+"category."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select also the commune and zone in partner addresses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Sales Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Set up a rule for unique partners based on vat, nrc and company."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv2
+msgid "Supplier  Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "The values used for stock out operations will not follow FIFO rule!"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid ""
+"This account will be used as an intermediary account for account move line "
+"generated from internal moves between company stores."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"This account will be used as the default non deductible expense account from"
+"                                 tax repartition lines marked as not "
+"deductible. If the line account does not                                 "
+"have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid ""
+"This account will be used as the default non deductible expense account from"
+" tax repartition lines marked as not deductible. If the line account does "
+"not have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid ""
+"This account will be used as the extra trial balance payable account for the"
+" current partner on stock picking received in custody."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid ""
+"This account will be used as the not eligible tax account for account move line.\n"
+"Used in especially in inventory losses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid ""
+"This account will be used as the payable account for the current partner on "
+"stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid ""
+"This account will be used as the receivable account for the current partner "
+"on stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid ""
+"This account will be used as the usage giving account in account move line."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid ""
+"This allows you to close accounts on periods based on templates: Income, "
+"Expense, VAT..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid ""
+"This allows you to create partners based on VAT:\n"
+"Romanian partners will be create based on ANAF webservice.\n"
+"European partners will be create based on VIES webservice (for countries that allow). \n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid ""
+"This allows you to manage price differences between receptions and invoices.\n"
+"It will be done by using landed cost, to also threat deliveries between reception and supplier invoice confirmation.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid ""
+"This allows you to manage the Romanian Cities:\n"
+" The address fields will contain city, municipality, siruta."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid ""
+"This allows you to manage the Romanian Stock Accounting, for locations with warehouse merchandise, including:\n"
+"New stock accounts on location to allow moving entry in accounting based on the stock move.\n"
+"The account entry will be generated from stock move instead of stock quant, link with the generated account move lines on the picking\n"
+"Inventory account move lines..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid ""
+"This allows you to manage the Romanian Zones, Communes\n"
+" The address fields will contain new many2one to communes and zones."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid ""
+"This allows you to manage the vat subjected and vat on payment fields update:\n"
+"For Romanian partners based on ANAF webservice.\n"
+"For European partners based on VIES data."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "This allows you to print invoice report based on romanian layout.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "This allows you to set unique partners by company, VAT and NRC."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "This allows you to set up the Accounting Date on stock operation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid ""
+"This allows you to set up the Accounting Date on stock operation.The "
+"Accounting Date will be showed up in confirmation wizards."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "This allows you to the currency rate in invoices.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid ""
+"This module add on each warehouse methods of usage giving and consumption"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid ""
+"This module will download data from ANAF site and when you give or receive a"
+" invoice will set fiscal position for VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "This option allows you to manage the sync to ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid ""
+"This option allows you to manage the update of currency rate based from BNR "
+"site."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty "
+"commissions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid ""
+"This product will be used to create the landed costfor the price difference "
+"between picking and bill"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid ""
+"Tracking (Lot/Serial) has to be enabled first for all stockable and "
+"consumable products !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update partners data based on the vat code from ANAF website in cron job."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update stock valuation in case of price difference between reception and "
+"bill."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Updates stock accounting according to Romanian Legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Upload Romanian cities, so you can select them more easily."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__anglo_saxon_accounting
+msgid "Use anglo-saxon accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "VAT number without country code."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid "VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid ""
+"Will update daily from cron only if is checked Automatic Currency Rates "
+"(OCA) and you added a rate_provider."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "cont stock marfa primita in custodie (creeat nou extrabilantier)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"use 4428 cont pentru tva neexigibil in notele facute pentru 'Marfa in "
+"magazin'"
+msgstr ""

--- a/l10n_ro_config/i18n/fr.po
+++ b/l10n_ro_config/i18n/fr.po
@@ -1,0 +1,1016 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-02 07:42+0000\n"
+"PO-Revision-Date: 2025-04-02 07:42+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Account:</strong>"
+msgstr "<strong>Compte:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Address:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Bank:</strong>"
+msgstr "<strong>Banque:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Company</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>NRC:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Share Capital:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "ANAF Integration"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "Account ANAF Sync"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a mechanism to close Incomes, Expense, VAT on a period base."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a stock sheet report for products grouped by Location, Account."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add a vat on payment field in partners, change the fiscal position with the "
+"one defined in settings depending on the partner and invoice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add company field for no signature, update invoice report for multi "
+"currency."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add predefined layouts to stock reports."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add valued reports for stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Adds location in_custody, usage_giving, consume *merchandise_type: store, "
+"warehouse."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__use_anglo_saxon
+msgid "Anglo-Saxon Accounting"
+msgstr "Comptabilité anglo-saxone"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Comptes bancaires"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_company
+msgid "Companies"
+msgstr "Sociétés"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Complete also staircase in extended address for partners."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_config_settings
+msgid "Config Settings"
+msgstr "Paramètres de configuration"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid "Create Partners by VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Create partners based on the vat code from ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid "Currency Rate Update BNR"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Currency rate in invoice is editable, so you can use your own currency rate."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv1
+msgid "Customer Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default Services Taxes"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default taxes applied to local transactions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Extend the  partner addres field with flat number, staircase.."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_receipt
+msgid "Fiscal Receipts Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"If this field is checked and the company use Romanian Accounting, the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule; If this field is NOT checked and the "
+"company use Romanian Accounting, the value used for stock out operations "
+"will be the value provided by FIFO rule, applied strictly on a location "
+"level (including its children)."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the "
+"currency rate differences between reception and invoice will be reflected in"
+" the stock valuation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule;If this field is NOT checked and the "
+"company use Romanian Accounting,the value used for stock out operations will"
+" be the value provided by FIFO rule, applied strictly on a location level "
+"(including its children)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Install BNR update rates"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__normal
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "Invoice Edit Currency Rate"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "Invoice Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_ir_ui_menu__is_l10n_ro_record
+msgid "Is L10N Ro Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_l10n_ro_mixin__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__is_l10n_ro_record
+msgid "Is Romanian Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation_visible
+msgid "L10N Ro Stock Account Svl Lot Allocation Visible"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Mark stock operations as notice operations. Stock accounting will change to "
+"use and accounts."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_ir_ui_menu
+msgid "Menu"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_l10n_ro_mixin
+msgid "Mixin model for applying to any object that use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "Notification !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Partners & Addresses"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid "Partners Fiscal Validation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "Partners unique by Company, VAT, NRC"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Print custom receipt report for Romanian companies."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_print_report
+msgid "Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_product_template
+msgid "Product"
+msgstr "Produit"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record DVI directly from invoices."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record cost of goods sold in your journal entries."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record price differences between bills and reception through Landed Cost"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record the payment directly to bank or cash statement. Set up different "
+"sequences for cash operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register non deductible VAT in accounting and stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register sync oAuth with ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Registration of accounting moves according to Romanian legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+msgid "Restrict Stock Move Date Future"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict Stock Move Date Last Month"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting in the last month."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict stock move posting with at most one month ago."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting with future date."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.view_account_bank_journal_form
+msgid "Ro Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_partner_id
+msgid "Romania - Autoinvoice Partner"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_sequence_type
+msgid "Romania - Autoinvoice Sequence Type"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_caen_code
+msgid "Romania - CAEN Code"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid "Romania - Company Stock Transfer Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid "Romania - Customs Commission Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid "Romania - Customs Duty Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_purchase_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_purchase_tax_id
+msgid "Romania - Default Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_sale_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_sale_tax_id
+msgid "Romania - Default Services Sale Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_e_invoice
+msgid "Romania - E-Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_position_id
+msgid "Romania - Fiscal Position"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_inverse_taxation_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_inverse_taxation_position_id
+msgid "Romania - Fiscal Position for Inverse Taxation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_vat_on_payment_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_vat_on_payment_position_id
+msgid "Romania - Fiscal Position for VAT on Payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid "Romania - Non Deductible Expense Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid "Romania - Not Eligible Tax Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid "Romania - Picking Account Custody"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid "Romania - Picking Account Payable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid "Romania - Picking Account Receivable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid "Romania - Price Difference Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__l10n_ro_print_report
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__l10n_ro_print_report
+msgid "Romania - Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_share_capital
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_share_capital
+msgid "Romania - Share Capital"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid "Romania - Stock Accounting Valuation Lot/Serial allocation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid "Romania - Stock Valuation Update"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_granted_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_granted_account_id
+msgid "Romania - Trade discounts granted"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_received_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_received_account_id
+msgid "Romania - Trade discounts received"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid "Romania - Usage Giving Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_accounting
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_accounting
+msgid "Romania - Use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_subjected
+msgid "Romania - VAT Subjected"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "Romania - VAT number digits"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid "Romania Account Period Close"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:res.groups,name:l10n_ro_config.group_ro_menus
+msgid "Romania Menus"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_nondeductible_vat
+msgid "Romania Non Deductible VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_receipt_report
+msgid "Romania Payment Receipt Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_to_statement
+msgid "Romania Payment to Statement"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid "Romanian Cities"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_dvi
+msgid "Romanian DVI"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Romanian Extended Address"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid "Romanian SIRUTA"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid "Romanian Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_notice
+msgid "Romanian Stock Account Notice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid "Romanian Stock Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "Romanian Stock Accounting Date"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid "Romanian Stock Accounting Date Wizard"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid "Romanian Stock Accounting Price Difference"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_comment_template
+msgid "Romanian Stock Picking Comment Template"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_valued_report
+msgid "Romanian Stock Picking Valued Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_report
+msgid "Romanian Stock Sheet Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "România"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 408"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 418"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 482"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 8035"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select Accounting Date in stock operations wizard."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select Accounting Date in stock operations. All transactions will have the "
+"Accounting Date as the used date in stock."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a expense account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs commission "
+"registration in landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs duty registration in "
+"landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in landed cost to register price "
+"differences.<br/>An expense account needs to be set on product or product "
+"category."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select also the commune and zone in partner addresses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Sales Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Set up a rule for unique partners based on vat, nrc and company."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv2
+msgid "Supplier  Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "The values used for stock out operations will not follow FIFO rule!"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid ""
+"This account will be used as an intermediary account for account move line "
+"generated from internal moves between company stores."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"This account will be used as the default non deductible expense account from"
+"                                 tax repartition lines marked as not "
+"deductible. If the line account does not                                 "
+"have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid ""
+"This account will be used as the default non deductible expense account from"
+" tax repartition lines marked as not deductible. If the line account does "
+"not have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid ""
+"This account will be used as the extra trial balance payable account for the"
+" current partner on stock picking received in custody."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid ""
+"This account will be used as the not eligible tax account for account move line.\n"
+"Used in especially in inventory losses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid ""
+"This account will be used as the payable account for the current partner on "
+"stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid ""
+"This account will be used as the receivable account for the current partner "
+"on stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid ""
+"This account will be used as the usage giving account in account move line."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid ""
+"This allows you to close accounts on periods based on templates: Income, "
+"Expense, VAT..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid ""
+"This allows you to create partners based on VAT:\n"
+"Romanian partners will be create based on ANAF webservice.\n"
+"European partners will be create based on VIES webservice (for countries that allow). \n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid ""
+"This allows you to manage price differences between receptions and invoices.\n"
+"It will be done by using landed cost, to also threat deliveries between reception and supplier invoice confirmation.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid ""
+"This allows you to manage the Romanian Cities:\n"
+" The address fields will contain city, municipality, siruta."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid ""
+"This allows you to manage the Romanian Stock Accounting, for locations with warehouse merchandise, including:\n"
+"New stock accounts on location to allow moving entry in accounting based on the stock move.\n"
+"The account entry will be generated from stock move instead of stock quant, link with the generated account move lines on the picking\n"
+"Inventory account move lines..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid ""
+"This allows you to manage the Romanian Zones, Communes\n"
+" The address fields will contain new many2one to communes and zones."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid ""
+"This allows you to manage the vat subjected and vat on payment fields update:\n"
+"For Romanian partners based on ANAF webservice.\n"
+"For European partners based on VIES data."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "This allows you to print invoice report based on romanian layout.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "This allows you to set unique partners by company, VAT and NRC."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "This allows you to set up the Accounting Date on stock operation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid ""
+"This allows you to set up the Accounting Date on stock operation.The "
+"Accounting Date will be showed up in confirmation wizards."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "This allows you to the currency rate in invoices.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid ""
+"This module add on each warehouse methods of usage giving and consumption"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid ""
+"This module will download data from ANAF site and when you give or receive a"
+" invoice will set fiscal position for VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "This option allows you to manage the sync to ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid ""
+"This option allows you to manage the update of currency rate based from BNR "
+"site."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty "
+"commissions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid ""
+"This product will be used to create the landed costfor the price difference "
+"between picking and bill"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid ""
+"Tracking (Lot/Serial) has to be enabled first for all stockable and "
+"consumable products !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update partners data based on the vat code from ANAF website in cron job."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update stock valuation in case of price difference between reception and "
+"bill."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Updates stock accounting according to Romanian Legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Upload Romanian cities, so you can select them more easily."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__anglo_saxon_accounting
+msgid "Use anglo-saxon accounting"
+msgstr "Utiliser la comptabilité anglo-saxonne"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "VAT number without country code."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid "VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid ""
+"Will update daily from cron only if is checked Automatic Currency Rates "
+"(OCA) and you added a rate_provider."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "cont stock marfa primita in custodie (creeat nou extrabilantier)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"use 4428 cont pentru tva neexigibil in notele facute pentru 'Marfa in "
+"magazin'"
+msgstr ""

--- a/l10n_ro_config/i18n/it.po
+++ b/l10n_ro_config/i18n/it.po
@@ -1,0 +1,1016 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ro_config
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-02 07:45+0000\n"
+"PO-Revision-Date: 2025-04-02 07:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Account:</strong>"
+msgstr "<strong>Conto:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Address:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.banks
+msgid "<strong>Bank:</strong>"
+msgstr "<strong>Banca:</strong>"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Company</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>NRC:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
+msgid "<strong>Share Capital:</strong>"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "ANAF Integration"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "Account ANAF Sync"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a mechanism to close Incomes, Expense, VAT on a period base."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add a stock sheet report for products grouped by Location, Account."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add a vat on payment field in partners, change the fiscal position with the "
+"one defined in settings depending on the partner and invoice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Add company field for no signature, update invoice report for multi "
+"currency."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add predefined layouts to stock reports."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Add valued reports for stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Adds location in_custody, usage_giving, consume *merchandise_type: store, "
+"warehouse."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__use_anglo_saxon
+msgid "Anglo-Saxon Accounting"
+msgstr "Contabilità anglosassone"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner_bank
+msgid "Bank Accounts"
+msgstr "Conti bancari"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_company
+msgid "Companies"
+msgstr "Aziende"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Complete also staircase in extended address for partners."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_config_settings
+msgid "Config Settings"
+msgstr "Impostazioni di configurazione"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_res_partner
+msgid "Contact"
+msgstr "Contatto"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid "Create Partners by VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Create partners based on the vat code from ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid "Currency Rate Update BNR"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Currency rate in invoice is editable, so you can use your own currency rate."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv1
+msgid "Customer Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default Services Taxes"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Default taxes applied to local transactions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Extend the  partner addres field with flat number, staircase.."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_receipt
+msgid "Fiscal Receipts Journal"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"If this field is checked and the company use Romanian Accounting, the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule; If this field is NOT checked and the "
+"company use Romanian Accounting, the value used for stock out operations "
+"will be the value provided by FIFO rule, applied strictly on a location "
+"level (including its children)."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the "
+"currency rate differences between reception and invoice will be reflected in"
+" the stock valuation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid ""
+"If this field is checked and the company use Romanian Accounting,the value "
+"used for stock out operations will be the value recorded at the reception of"
+" the lot/serial, ignoring FIFO rule;If this field is NOT checked and the "
+"company use Romanian Accounting,the value used for stock out operations will"
+" be the value provided by FIFO rule, applied strictly on a location level "
+"(including its children)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Install BNR update rates"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__normal
+msgid "Invoice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "Invoice Edit Currency Rate"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "Invoice Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_ir_ui_menu__is_l10n_ro_record
+msgid "Is L10N Ro Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_l10n_ro_mixin__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_product__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_product_template__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__is_l10n_ro_record
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__is_l10n_ro_record
+msgid "Is Romanian Record"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_account_journal
+msgid "Journal"
+msgstr "Registro"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation_visible
+msgid "L10N Ro Stock Account Svl Lot Allocation Visible"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Mark stock operations as notice operations. Stock accounting will change to "
+"use and accounts."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_ir_ui_menu
+msgid "Menu"
+msgstr "Menù"
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_l10n_ro_mixin
+msgid "Mixin model for applying to any object that use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "Notification !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Partners & Addresses"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid "Partners Fiscal Validation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "Partners unique by Company, VAT, NRC"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Print custom receipt report for Romanian companies."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_print_report
+msgid "Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model,name:l10n_ro_config.model_product_template
+msgid "Product"
+msgstr "Prodotto"
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record DVI directly from invoices."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Record cost of goods sold in your journal entries."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record price differences between bills and reception through Landed Cost"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Record the payment directly to bank or cash statement. Set up different "
+"sequences for cash operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register non deductible VAT in accounting and stock operations."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Register sync oAuth with ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Registration of accounting moves according to Romanian legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+msgid "Restrict Stock Move Date Future"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict Stock Move Date Last Month"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting in the last month."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_last_month
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_last_month
+msgid "Restrict stock move posting with at most one month ago."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_restrict_stock_move_date_future
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_restrict_stock_move_date_future
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Restrict stock move posting with future date."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.view_account_bank_journal_form
+msgid "Ro Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_partner_id
+msgid "Romania - Autoinvoice Partner"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_sequence_type
+msgid "Romania - Autoinvoice Sequence Type"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_caen_code
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_caen_code
+msgid "Romania - CAEN Code"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid "Romania - Company Stock Transfer Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid "Romania - Customs Commission Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid "Romania - Customs Duty Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_purchase_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_purchase_tax_id
+msgid "Romania - Default Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_account_serv_sale_tax_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_serv_sale_tax_id
+msgid "Romania - Default Services Sale Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_e_invoice
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_e_invoice
+msgid "Romania - E-Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_journal__l10n_ro_fiscal_position_id
+msgid "Romania - Fiscal Position"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_inverse_taxation_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_inverse_taxation_position_id
+msgid "Romania - Fiscal Position for Inverse Taxation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_vat_on_payment_position_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_vat_on_payment_position_id
+msgid "Romania - Fiscal Position for VAT on Payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid "Romania - Non Deductible Expense Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid "Romania - Not Eligible Tax Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid "Romania - Picking Account Custody"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid "Romania - Picking Account Payable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid "Romania - Picking Account Receivable"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid "Romania - Price Difference Landed Cost Product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_account_setup_bank_manual_config__l10n_ro_print_report
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner_bank__l10n_ro_print_report
+msgid "Romania - Print in Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_share_capital
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_share_capital
+msgid "Romania - Share Capital"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_account_svl_lot_allocation
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_account_svl_lot_allocation
+msgid "Romania - Stock Accounting Valuation Lot/Serial allocation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_stock_acc_price_diff
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_stock_acc_price_diff
+msgid "Romania - Stock Valuation Update"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_granted_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_granted_account_id
+msgid "Romania - Trade discounts granted"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_trade_discount_received_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_trade_discount_received_account_id
+msgid "Romania - Trade discounts received"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid "Romania - Usage Giving Account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__l10n_ro_accounting
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__l10n_ro_accounting
+msgid "Romania - Use Romanian Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_subjected
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_subjected
+msgid "Romania - VAT Subjected"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "Romania - VAT number digits"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid "Romania Account Period Close"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:res.groups,name:l10n_ro_config.group_ro_menus
+msgid "Romania Menus"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_nondeductible_vat
+msgid "Romania Non Deductible VAT"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_receipt_report
+msgid "Romania Payment Receipt Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_payment_to_statement
+msgid "Romania Payment to Statement"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid "Romanian Cities"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_dvi
+msgid "Romanian DVI"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_address_extended
+msgid "Romanian Extended Address"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid "Romanian SIRUTA"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid "Romanian Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_notice
+msgid "Romanian Stock Account Notice"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid "Romanian Stock Accounting"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "Romanian Stock Accounting Date"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid "Romanian Stock Accounting Date Wizard"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid "Romanian Stock Accounting Price Difference"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_comment_template
+msgid "Romanian Stock Picking Comment Template"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_picking_valued_report
+msgid "Romanian Stock Picking Valued Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_report
+msgid "Romanian Stock Sheet Report"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "România"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 408"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 418"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 482"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select 8035"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select Accounting Date in stock operations wizard."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select Accounting Date in stock operations. All transactions will have the "
+"Accounting Date as the used date in stock."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a expense account"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select a product"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs commission "
+"registration in landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in customs duty registration in "
+"landed cost."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Select a service product that will be used in landed cost to register price "
+"differences.<br/>An expense account needs to be set on product or product "
+"category."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Select also the commune and zone in partner addresses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Purchase Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid "Services Sales Tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Set up a rule for unique partners based on vat, nrc and company."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Stock"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields.selection,name:l10n_ro_config.selection__account_journal__l10n_ro_sequence_type__autoinv2
+msgid "Supplier  Auto Invoicing"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid "The values used for stock out operations will not follow FIFO rule!"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_transfer_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_transfer_account_id
+msgid ""
+"This account will be used as an intermediary account for account move line "
+"generated from internal moves between company stores."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"This account will be used as the default non deductible expense account from"
+"                                 tax repartition lines marked as not "
+"deductible. If the line account does not                                 "
+"have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_nondeductible_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_nondeductible_account_id
+msgid ""
+"This account will be used as the default non deductible expense account from"
+" tax repartition lines marked as not deductible. If the line account does "
+"not have a non deductible account set, this account will be used."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_custody_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_custody_account_id
+msgid ""
+"This account will be used as the extra trial balance payable account for the"
+" current partner on stock picking received in custody."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_uneligible_tax_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_uneligible_tax_account_id
+msgid ""
+"This account will be used as the not eligible tax account for account move line.\n"
+"Used in especially in inventory losses."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_payable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_payable_account_id
+msgid ""
+"This account will be used as the payable account for the current partner on "
+"stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_picking_receivable_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_picking_receivable_account_id
+msgid ""
+"This account will be used as the receivable account for the current partner "
+"on stock picking notice."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_usage_giving_account_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_usage_giving_account_id
+msgid ""
+"This account will be used as the usage giving account in account move line."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_period_close
+msgid ""
+"This allows you to close accounts on periods based on templates: Income, "
+"Expense, VAT..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_create_by_vat
+msgid ""
+"This allows you to create partners based on VAT:\n"
+"Romanian partners will be create based on ANAF webservice.\n"
+"European partners will be create based on VIES webservice (for countries that allow). \n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_price_difference
+msgid ""
+"This allows you to manage price differences between receptions and invoices.\n"
+"It will be done by using landed cost, to also threat deliveries between reception and supplier invoice confirmation.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_city
+msgid ""
+"This allows you to manage the Romanian Cities:\n"
+" The address fields will contain city, municipality, siruta."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account
+msgid ""
+"This allows you to manage the Romanian Stock Accounting, for locations with warehouse merchandise, including:\n"
+"New stock accounts on location to allow moving entry in accounting based on the stock move.\n"
+"The account entry will be generated from stock move instead of stock quant, link with the generated account move lines on the picking\n"
+"Inventory account move lines..."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_siruta
+msgid ""
+"This allows you to manage the Romanian Zones, Communes\n"
+" The address fields will contain new many2one to communes and zones."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_fiscal_validation
+msgid ""
+"This allows you to manage the vat subjected and vat on payment fields update:\n"
+"For Romanian partners based on ANAF webservice.\n"
+"For European partners based on VIES data."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_report_invoice
+msgid "This allows you to print invoice report based on romanian layout.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_partner_unique
+msgid "This allows you to set unique partners by company, VAT and NRC."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date
+msgid "This allows you to set up the Accounting Date on stock operation"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock_account_date_wizard
+msgid ""
+"This allows you to set up the Accounting Date on stock operation.The "
+"Accounting Date will be showed up in confirmation wizards."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_edit_currency_rate
+msgid "This allows you to the currency rate in invoices.\n"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_stock
+msgid ""
+"This module add on each warehouse methods of usage giving and consumption"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid ""
+"This module will download data from ANAF site and when you give or receive a"
+" invoice will set fiscal position for VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_l10n_ro_account_anaf_sync
+msgid "This option allows you to manage the sync to ANAF website."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__module_currency_rate_update_RO_BNR
+msgid ""
+"This option allows you to manage the update of currency rate based from BNR "
+"site."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_commission_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_commission_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty "
+"commissions."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_customs_duty_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_customs_duty_product_id
+msgid ""
+"This product will be used in create the DVI landed costfor the duty tax"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_res_company__l10n_ro_property_stock_price_difference_product_id
+#: model:ir.model.fields,help:l10n_ro_config.field_res_config_settings__l10n_ro_property_stock_price_difference_product_id
+msgid ""
+"This product will be used to create the landed costfor the price difference "
+"between picking and bill"
+msgstr ""
+
+#. module: l10n_ro_config
+#. odoo-python
+#: code:addons/l10n_ro_config/wizard/res_config_settings.py:0
+#, python-format
+msgid ""
+"Tracking (Lot/Serial) has to be enabled first for all stockable and "
+"consumable products !"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update partners data based on the vat code from ANAF website in cron job."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"Update stock valuation in case of price difference between reception and "
+"bill."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Updates stock accounting according to Romanian Legislation."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "Upload Romanian cities, so you can select them more easily."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_company__anglo_saxon_accounting
+msgid "Use anglo-saxon accounting"
+msgstr "Usare contabilità anglosassone"
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,help:l10n_ro_config.field_marketplace_customer__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_partner__l10n_ro_vat_number
+#: model:ir.model.fields,help:l10n_ro_config.field_res_users__l10n_ro_vat_number
+msgid "VAT number without country code."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model:ir.model.fields,field_description:l10n_ro_config.field_res_config_settings__module_l10n_ro_vat_on_payment
+msgid "VAT on payment"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_account_view_form
+msgid ""
+"Will update daily from cron only if is checked Automatic Currency Rates "
+"(OCA) and you added a rate_provider."
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid "cont stock marfa primita in custodie (creeat nou extrabilantier)"
+msgstr ""
+
+#. module: l10n_ro_config
+#: model_terms:ir.ui.view,arch_db:l10n_ro_config.res_config_settings_view_form
+msgid ""
+"use 4428 cont pentru tva neexigibil in notele facute pentru 'Marfa in "
+"magazin'"
+msgstr ""

--- a/l10n_ro_config/models/account_journal.py
+++ b/l10n_ro_config/models/account_journal.py
@@ -18,6 +18,12 @@ class AccountJournal(models.Model):
 
     l10n_ro_fiscal_receipt = fields.Boolean("Fiscal Receipts Journal")
 
+    l10n_ro_fiscal_position_id = fields.Many2one(
+        "account.fiscal.position",
+        "Romania - Fiscal Position",
+        domain="[('company_id', '=', company_id)]",
+    )
+
     @api.depends("bank_account_id.l10n_ro_print_report")
     def _compute_l10n_ro_print_report(self):
         for jr in self:

--- a/l10n_ro_config/models/res_partner.py
+++ b/l10n_ro_config/models/res_partner.py
@@ -54,7 +54,10 @@ class ResPartner(models.Model):
     @api.onchange("l10n_ro_vat_subjected")
     def onchange_l10n_ro_vat_subjected(self):
         if self.is_l10n_ro_record:
-            if not self.env.context.get("skip_ro_vat_change"):
+            if (
+                not self.env.context.get("skip_ro_vat_change")
+                and self.country_id.code == "RO"
+            ):
                 if self.vat and self.vat.isdigit() and self.l10n_ro_vat_subjected:
                     vat_country = self._l10n_ro_map_vat_country_code(
                         self.country_id.code.upper()

--- a/l10n_ro_config/views/account_journal.xml
+++ b/l10n_ro_config/views/account_journal.xml
@@ -17,9 +17,9 @@
         <field name="inherit_id" ref="account.view_account_journal_form" />
         <field name="arch" type="xml">
             <xpath expr="//group/field[@name='company_id']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_print_report" readonly="False" />
                 <field name="l10n_ro_fiscal_receipt" />
+                <field name="l10n_ro_fiscal_position_id" />
             </xpath>
         </field>
     </record>

--- a/l10n_ro_config/views/res_bank_view.xml
+++ b/l10n_ro_config/views/res_bank_view.xml
@@ -6,7 +6,6 @@
         <field name="inherit_id" ref="base.view_partner_bank_form" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_print_report" />
             </field>
         </field>
@@ -17,7 +16,6 @@
         <field name="inherit_id" ref="base.view_partner_bank_tree" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_print_report" />
             </field>
         </field>

--- a/l10n_ro_config/views/res_partner_view.xml
+++ b/l10n_ro_config/views/res_partner_view.xml
@@ -5,9 +5,6 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <form position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
-            </form>
             <field name="nrc" position="attributes">
                 <attribute name="invisible">not is_company</attribute>
             </field>

--- a/l10n_ro_config/wizard/res_config_settings_views.xml
+++ b/l10n_ro_config/wizard/res_config_settings_views.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="base.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <form position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field
                     name="country_code"
                     invisible="1"


### PR DESCRIPTION
Câmpul `is_l10n_ro_record`, marcat ca invizibil în formularele și listele partenerilor bancari, a fost eliminat deoarece nu mai este necesar. În plus, a fost adăugat un fișier de traduceri în limba franceză pentru modulul `l10n_ro_config`.