### PR TITLE
[18.0][IMP] Actualizează logica salvării orașelor în res.partner

### DIFF
--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -46,7 +46,13 @@ class Partner(models.Model):
                 city = self.env["res.city"].search(domain, limit=1)
 
             if city:
-                self.city_id = city
+                self.write(
+                    {
+                        "city_id": city.id,
+                        "city": city.name,
+                        "state_id": city.state_id.id,
+                    }
+                )
 
     @api.onchange("city_id")
     def _onchange_city_id(self):

--- a/l10n_ro_city/views/res_city_view.xml
+++ b/l10n_ro_city/views/res_city_view.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="base_address_extended.view_city_tree" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_municipality" />
                 <field name="l10n_ro_siruta" />
             </field>


### PR DESCRIPTION
Modificările optimizează actualizarea câmpurilor asociate orașelor în modelul res.partner, asigurând o scriere consistentă a datelor. În plus, au fost eliminate câmpuri redundante din vizualizarea res.city pentru un cod mai clar și eficient.