### PR TITLE
[18.0][IMP] Adaugă gestionarea poziției fiscale în funcționalitatea stock.

### DIFF
--- a/l10n_ro_stock_account/models/account_move.py
+++ b/l10n_ro_stock_account/models/account_move.py
@@ -109,3 +109,18 @@ class AccountMoveLine(models.Model):
     def _get_account_change_stock_moves_sale(self):
         sales = self.sale_line_ids.filtered(lambda s: s.move_ids)
         return sales.move_ids
+
+    def _prepare_create_values(self, vals_list):
+        result_vals_list = super()._prepare_create_values(vals_list)
+        for vals in result_vals_list:
+            move_id = vals.get("move_id", False)
+            account_id = vals.get("account_id", False)
+            if move_id and account_id:
+                move = self.env["account.move"].browse(move_id)
+                account = self.env["account.account"].browse(account_id)
+                journal = move.journal_id
+                fiscal_position = journal.l10n_ro_fiscal_position_id
+                if fiscal_position:
+                    account = fiscal_position.map_account(account)
+                    vals["account_id"] = account.id
+        return result_vals_list

--- a/l10n_ro_stock_account/models/product_template.py
+++ b/l10n_ro_stock_account/models/product_template.py
@@ -25,6 +25,10 @@ class ProductTemplate(models.Model):
         "use the category value. ",
     )
 
+    def get_product_accounts(self, fiscal_pos=None):
+        fiscal_pos = fiscal_pos or self.env.context.get("fiscal_pos")
+        return super().get_product_accounts(fiscal_pos)
+
     def _get_product_accounts(self):
         accounts = super()._get_product_accounts()
 

--- a/l10n_ro_stock_account/models/stock_picking.py
+++ b/l10n_ro_stock_account/models/stock_picking.py
@@ -5,7 +5,14 @@
 
 from ast import literal_eval
 
-from odoo import models
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _name = "stock.picking.type"
+    _inherit = ["stock.picking.type", "l10n.ro.mixin"]
+
+    l10n_ro_fiscal_position_id = fields.Many2one("account.fiscal.position")
 
 
 class StockPicking(models.Model):

--- a/l10n_ro_stock_account/views/account_account_view.xml
+++ b/l10n_ro_stock_account/views/account_account_view.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="account.view_account_form" />
         <field name="arch" type="xml">
             <field name="tax_ids" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_stock_consume_account_id" />
             </field>
         </field>

--- a/l10n_ro_stock_account/views/product_category_view.xml
+++ b/l10n_ro_stock_account/views/product_category_view.xml
@@ -6,7 +6,6 @@
         <field name="priority" eval="50" />
         <field name="arch" type="xml">
             <field name="property_stock_valuation_account_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_stock_account_change" />
                 <field name="l10n_ro_hide_stock_in_out_account" invisible="1" />
             </field>

--- a/l10n_ro_stock_account/views/product_template_view.xml
+++ b/l10n_ro_stock_account/views/product_template_view.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="account.product_template_form_view" />
         <field name="arch" type="xml">
             <field name="property_account_expense_id" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field
                     name="l10n_ro_property_stock_valuation_account_id"
                     domain="[('deprecated','=',False)]"

--- a/l10n_ro_stock_account/views/stock_location_view.xml
+++ b/l10n_ro_stock_account/views/stock_location_view.xml
@@ -14,7 +14,7 @@
                         name="valuation_out_account_id"
                         options="{'no_create': True}"
                     />
-                    <field name="is_l10n_ro_record" invisible="1" />
+
                     <separator string="Only for Romania" />
                     <field
                         name="l10n_ro_property_account_income_location_id"

--- a/l10n_ro_stock_account/views/stock_picking_view.xml
+++ b/l10n_ro_stock_account/views/stock_picking_view.xml
@@ -4,13 +4,7 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_assign_serial']" position="before">
-                <field name="is_l10n_ro_record" invisible="1" />
-                <field name="picking_code" invisible="1" />
-                <field name="price_unit" invisible="picking_code != 'incoming'" />
-            </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <button
                     string="Journal Items"
                     type="object"
@@ -34,6 +28,17 @@
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face" />
             <p />
+        </field>
+    </record>
+
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">stock.picking.type.inherit</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='warehouse_id']" position="after">
+                <field name="l10n_ro_fiscal_position_id" />
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/l10n_ro_stock_account/views/stock_valuation_layer_views.xml
+++ b/l10n_ro_stock_account/views/stock_valuation_layer_views.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="stock_account.stock_valuation_layer_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='stock_move_id']" position="after">
-                <field name="is_l10n_ro_record" invisible="1" />
                 <field name="l10n_ro_valued_type" />
             </xpath>
             <xpath expr="//field[@name='account_move_id']" position="after">


### PR DESCRIPTION
Se introduce câmpul `l10n_ro_fiscal_position_id` în modelul `stock.picking.type` și se extinde logica de alocare a conturilor contabile conform poziției fiscale. De asemenea, s-au eliminat câmpurile redundante `is_l10n_ro_record` pentru a simplifica structura XML și modelele.