### PR TITLE
[18.0][IMP] Actualizează logica câmpului `l10n_ro_external_code`

### DIFF
--- a/l10n_ro_account/models/account_account.py
+++ b/l10n_ro_account/models/account_account.py
@@ -8,7 +8,7 @@ class Account(models.Model):
     _inherit = "account.account"
 
     l10n_ro_external_code = fields.Char(
-        compute="_compute_l10n_ro_external_code", store=True
+        compute="_compute_l10n_ro_external_code", store=False
     )
 
     @api.depends("code")
@@ -29,17 +29,17 @@ class Account(models.Model):
         return account_id
 
     def internal_to_external(self):
+        if self.code and not self.code.isdigit():
+            return self.code
         if not self.code or len(self.code) < 4:
             return self.code
         cont = self.code[:4]
         while cont and cont[-1] == "0":
             cont = cont[:-1]
-        try:
-            analitic = int(self.code[4:])
-        except Exception:
-            analitic = self.code[4:]
-        if analitic:
-            cont += "." + str(analitic)
+
+        analytic = int(self.code[4:])
+        if analytic:
+            cont += "." + str(analytic)
         return cont
 
     def _compute_display_name(self):


### PR DESCRIPTION
Setează `store=False` pentru câmpul calculat `l10n_ro_external_code` pentru a preveni stocarea acestuia în baza de date. Simplifică și corectează logica pentru procesarea codurilor analitice în metoda `internal_to_external`.