### PR TITLE
[18.0][FIX] Actualizează view_mode la "list" pentru multiple acțiuni

### DIFF
--- a/l10n_ro_account_period_close/views/account_period_close_view.xml
+++ b/l10n_ro_account_period_close/views/account_period_close_view.xml
@@ -13,7 +13,7 @@
     </record>
     <record id="act_account_period_closing_wizard" model="ir.actions.act_window">
         <field name="name">Close Period</field>
-        <field name="view_mode">form,tree</field>
+        <field name="view_mode">form,list</field>
         <field name="res_model">l10n.ro.account.period.closing.wizard</field>
         <field name="context">
             {'search_default_closing_id':[active_id], 'default_closing_id': active_id}

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -611,7 +611,7 @@ class MessageSPV(models.Model):
         action = {
             "type": "ir.actions.act_window",
             "res_model": "account.move",
-            "view_mode": "tree",
+            "view_mode": "list",
             "views": [(False, "list"), (False, "form")],
             "domain": [("id", "in", invoices.ids)],
         }


### PR DESCRIPTION
Înlocuiește "tree" cu "list" în view_mode pentru a asigura o mai bună consistență între vizualizări și standardele Odoo. Acest update afectează atât modelul "account.move", cât și wizard-ul pentru închiderea perioadei contabile.