### PR TITLE
[17.0][FIX] Corectează calculul prețului pentru mutările returnate

### DIFF
--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -813,6 +813,8 @@ class StockMove(models.Model):
         if not self.is_l10n_ro_record:
             return price_unit
         if self.origin_returned_move_id:
+            if not price_unit:
+                price_unit = self.origin_returned_move_id._get_price_unit()
             return price_unit
         if self.product_id.cost_method != "average":
             return price_unit


### PR DESCRIPTION
Adaugă o verificare pentru cazurile în care `price_unit` este nul, setând valoarea din mutarea returnată originală. Astfel, se evită erori în scenariile de returnare a produselor.