### PR TITLE
[18.0][FIX] Actualizează câmpurile utilizate pentru datele de producție

### DIFF
--- a/l10n_ro_stock_account_date/models/stock_move.py
+++ b/l10n_ro_stock_account_date/models/stock_move.py
@@ -24,9 +24,9 @@ class StockMove(models.Model):
                 new_date = self.date
             elif "raw_material_production_id" in self._fields:
                 if self.raw_material_production_id:
-                    new_date = self.raw_material_production_id.date_planned_start
+                    new_date = self.raw_material_production_id.date_start
                 elif self.production_id:
-                    new_date = self.production_id.date_planned_start
+                    new_date = self.production_id.date_start
             if not new_date:
                 new_date = fields.datetime.now()
         restrict_date_last_month = (


### PR DESCRIPTION
A fost modificată utilizarea câmpurilor `date_planned_start` cu `date_start` pentru obiectele `raw_material_production_id` și `production_id`. Aceasta asigură alinierea la actualizările recente ale modelului și corectitudinea datelor procesate.