### PR TITLE
[17.0][FIX] Ajustează conturile pentru retururile de livrare

### DIFF
--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -728,6 +728,9 @@ class StockMove(models.Model):
                 acc_src, acc_dest, acc_valuation
             )
 
+        if valued_type == "delivery_return":
+            acc_dest = acc_src
+
         # self.log_account(acc_src, acc_dest, acc_valuation, journal_id)
 
         journal_id = self._l10n_ro_get_journal_id(


### PR DESCRIPTION
Adaugă logica necesară pentru a seta contul de destinație egal cu cel de sursă în cazul retururilor de livrare. Aceasta corectează gestionarea contabilă pentru acest tip de mișcare.