### PR TITLE
[17.0][IMP] Corectează determinarea storno pentru mișcările de stoc

### DIFF
--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -548,8 +548,9 @@ class StockMove(models.Model):
             cost,
         )
         valued_type = self.env.context.get("valued_type", "indefinite")
-        if "return" in valued_type and self.env.company.account_storno:
-            vals["is_storno"] = True
+        if self.env.company.account_storno:
+            if "return" in valued_type or self.origin_returned_move_id:
+                vals["is_storno"] = True
         return vals
 
     def _l10n_ro_account_entry_move(self, qty, description, svl_id, cost):

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -548,7 +548,9 @@ class StockMove(models.Model):
             cost,
         )
         valued_type = self.env.context.get("valued_type", "indefinite")
-        if self.env.company.account_storno and ("return" in valued_type or self.origin_returned_move_id):
+        if self.env.company.account_storno and (
+            "return" in valued_type or self.origin_returned_move_id
+        ):
             vals["is_storno"] = True
         return vals
 

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -548,9 +548,8 @@ class StockMove(models.Model):
             cost,
         )
         valued_type = self.env.context.get("valued_type", "indefinite")
-        if self.env.company.account_storno:
-            if "return" in valued_type or self.origin_returned_move_id:
-                vals["is_storno"] = True
+        if self.env.company.account_storno and ("return" in valued_type or self.origin_returned_move_id):
+            vals["is_storno"] = True
         return vals
 
     def _l10n_ro_account_entry_move(self, qty, description, svl_id, cost):

--- a/l10n_ro_stock_account/tests/common.py
+++ b/l10n_ro_stock_account/tests/common.py
@@ -97,6 +97,7 @@ class TestStockCommon(ValuationReconciliationTestCommon):
         cls.env.company.anglo_saxon_accounting = True
         cls.env.company.l10n_ro_accounting = True
         cls.env.company.l10n_ro_stock_acc_price_diff = True
+        cls.env.company.account_storno = True
 
         cls.setUpAccounts()
 


### PR DESCRIPTION
Adaugă verificarea `origin_returned_move_id` pentru stabilirea corectă a câmpului `is_storno`. Aceasta asigură un comportament consistent pentru înregistrările contabile în cazul returnărilor.