### PR TITLE
[17][FIX] correct the filter for SVLs with different invoices

### DIFF
--- a/l10n_ro_stock_picking_valued_report/models/stock_move_line.py
+++ b/l10n_ro_stock_picking_valued_report/models/stock_move_line.py
@@ -95,8 +95,8 @@ class StockMoveLine(models.Model):
                                 s.stock_landed_cost_id
                                 and s.stock_landed_cost_id.l10n_ro_cost_type == "normal"
                                 and s.stock_landed_cost_id.vendor_bill_id
-                                and s.stock_landed_cost_id.vendor_bill_id
-                                != svls[0].l10n_ro_invoice_id
+                                # and s.stock_landed_cost_id.vendor_bill_id
+                                # != svls[0].l10n_ro_invoice_id
                             )
                         )
                         svls = svls - svls_lc_not_same_invoice


### PR DESCRIPTION
FIX: cand avem un landed cost distribuit pe mai multe receptii in PDF NIR nu mai apar costurile aditionale.