### PR TITLE
[17.0][IMP] Filtrează mesajele SPV fără erori sau notificări pt descarcare ZIP

### DIFF
--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -26,7 +26,11 @@ class ResCompany(models.Model):
 
         need_retrigger = False
         for company in ro_companies:
-            domain = [("company_id", "=", company.id), ("attachment_id", "=", False)]
+            domain = [
+                ("company_id", "=", company.id),
+                ("attachment_id", "=", False),
+                ("message_type", "not in", ["error", "message"]),
+            ]
             messages = company.env["l10n.ro.message.spv"].search(
                 domain, limit=limit + 1
             )


### PR DESCRIPTION
Adaugă o condiție suplimentară în domeniul de căutare pentru a exclude mesajele de tip „error” sau „message”. Această modificare optimizează procesarea mesajelor relevante pentru companie.