### PR TITLE
[18.0][FIX] Ignoră categoriile cu evaluare manuală periodică.

### DIFF
--- a/l10n_ro_stock_account/models/product_category.py
+++ b/l10n_ro_stock_account/models/product_category.py
@@ -47,6 +47,8 @@ class ProductCategory(models.Model):
         if self.env.company.l10n_ro_accounting:
             # is a romanian company:
             for record in self.filtered("is_l10n_ro_record"):
+                if record.property_valuation == "manual_periodic":
+                    continue
                 stock_input = record.property_stock_account_input_categ_id
                 stock_output = record.property_stock_account_output_categ_id
                 stock_val = record.property_stock_valuation_account_id


### PR DESCRIPTION
A fost adăugată o condiție care exclude categoriile de produse configurate cu evaluare `manual_periodic` din procesarea conturilor de stoc. Această modificare previne comportamentele neintenționate și îmbunătățește robustețea logicii de contabilizare.