### PR TITLE
[16.0][FIX] Compute fiscal position at creation

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -412,6 +412,7 @@ class MessageSPV(models.Model):
                 continue
             state = "invoice"
             message.write({"invoice_id": new_invoice.id, "state": state})
+            new_invoice._onchange_partner_id()
 
     def render_anaf_pdf(self):
         for message in self:


### PR DESCRIPTION
When the invoice is created it does not put the coresponding fiscal position. But if after creation you changed to the same partner it computes to the corrected one.
So we should call the function that computes the fiscal position based on partner