### PR TITLE
[18.0][FIX] Corectează traducerea pentru `<strong>NRC:</strong>`.

### DIFF
--- a/l10n_ro_account_bank_statement_report/i18n/ro.po
+++ b/l10n_ro_account_bank_statement_report/i18n/ro.po
@@ -56,7 +56,7 @@ msgstr "<strong>Departamentul Financiar-Contabil</strong>"
 #: model_terms:ir.ui.view,arch_db:l10n_ro_account_bank_statement_report.report_l10n_ro_statement_daily
 #: model_terms:ir.ui.view,arch_db:l10n_ro_account_bank_statement_report.report_l10n_ro_statement_period
 msgid "<strong>NRC:</strong>"
-msgstr "<strong>Consiliul national de cercetare:</strong>"
+msgstr "<strong>NRC:</strong>"
 
 #. module: l10n_ro_account_bank_statement_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_account_bank_statement_report.report_l10n_ro_statement_period

--- a/l10n_ro_config/i18n/ro.po
+++ b/l10n_ro_config/i18n/ro.po
@@ -41,7 +41,7 @@ msgstr "<strong>Companie</strong>"
 #. module: l10n_ro_config
 #: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company
 msgid "<strong>NRC:</strong>"
-msgstr "<strong>Consiliul National de Cercetare:</strong>"
+msgstr "<strong>NRC:</strong>"
 
 #. module: l10n_ro_config
 #: model_terms:ir.ui.view,arch_db:l10n_ro_config.report_address_company


### PR DESCRIPTION
A fost actualizată traducerea termenului `<strong>NRC:</strong>` pentru a elimina confuzia cu "Consiliul Național de Cercetare". Modificarea adresează inconsecvențele din fișierele `.po` pentru a reflecta mai bine contextul original.