### PR TITLE
[18.0][FIX] Adaugă validări pentru compatibilitatea dintre cod poștal, județ și oras

### DIFF
--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -2,7 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class Partner(models.Model):
@@ -20,12 +21,18 @@ class Partner(models.Model):
     @api.onchange("zip")
     def onchange_zip(self):
         if self.zip and self.country_id.code == "RO":
+            state_b = self.env.ref("base.RO_B")
+
             domain = [
                 ("l10n_ro_prefix_zip", "=", self.zip[:2]),
                 ("country_id", "=", self.country_id.id),
             ]
             state = self.env["res.country.state"].search(domain, limit=1)
             if state:
+                if self.state_id and self.state_id != state:
+                    raise UserError(
+                        _(f"The state {state.name} doesn't match the zip code")
+                    )
                 self.state_id = state
 
             if self.zip[:2] in ["01", "02", "03", "04", "05", "06"]:
@@ -38,6 +45,13 @@ class Partner(models.Model):
                     "06": "l10n_ro_city.RO_179196",  # Sector 6
                 }
                 city = self.env.ref(mapping[self.zip[:2]])
+                if self.state_id != state_b:
+                    raise UserError(
+                        _(
+                            f"The city {city.name} doesn't match the"
+                            f" zip code and the state {state.name}"
+                        )
+                    )
             else:
                 domain = [
                     ("zipcode", "=", self.zip),

--- a/l10n_ro_city/tests/test_ro_city.py
+++ b/l10n_ro_city/tests/test_ro_city.py
@@ -14,6 +14,7 @@ class TestRoCity(TransactionCase):
         self.city_2 = self.env.ref("l10n_ro_city.RO_21588")
         self.city_3 = self.env.ref("l10n_ro_city.RO_6734")
         self.state_bc = self.env.ref("base.RO_BC")
+        self.state_b = self.env.ref("base.RO_B")
 
     def test_city(self):
         self.assertEqual(self.city_1.name, "Filipești")
@@ -40,8 +41,10 @@ class TestRoCity(TransactionCase):
         partner_form = Form(self.env["res.partner"])
         partner_form.country_id = self.env.ref("base.ro")
         # competare cod postal filipesti
+        partner_form.state_id = self.state_bc
         partner_form.zip = "607185"
         self.assertEqual(partner_form.city_id.name, "Filipești")
 
+        partner_form.state_id = self.state_b
         partner_form.zip = "030011"
         self.assertEqual(partner_form.city_id.name, "Sector3")


### PR DESCRIPTION

Au fost implementate verificări suplimentare pentru a asigura coerența dintre codul poștal, județul și orașul selectat. Aceste modificări includ ridicarea de erori utilizatorului atunci când informațiile introduse nu corespund. De asemenea, au fost adăugate teste unitare pentru a valida noile funcționalități.