### PR TITLE
[17.0][IMP] camp pentru locatia de evaluare in svl && fixuri

### DIFF
--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -632,6 +632,18 @@ class StockMove(models.Model):
         account_move.action_post()
         return account_move
 
+    def _get_accounting_data_for_valuation_locations(self):
+        # metoda hook
+        # sa am posibilitatea de a returna locatiile de pe stock.move.line
+        # in cazul in care am locatie parinte (internal),
+        # cu mai multe locatii copil
+        # si locatiile copil au conturi pe ele
+        #
+        # stock.move este cu locatiile parinte,
+        # insa stock.move.line este setat pe locatii copil
+
+        return (self.location_id, self.location_dest_id)
+
     def _get_accounting_data_for_valuation(self):
         fiscal_pos = self.picking_id.picking_type_id.l10n_ro_fiscal_position_id
         self = self.with_context(fiscal_pos=fiscal_pos)
@@ -645,8 +657,8 @@ class StockMove(models.Model):
             return journal_id, acc_src, acc_dest, acc_valuation
 
         valued_type = self.env.context.get("valued_type", "indefinite")
-        location_from = self.location_id
-        location_to = self.location_dest_id
+
+        location_from, location_to = self._get_accounting_data_for_valuation_locations()
         location_from_account = (
             location_from.l10n_ro_property_stock_valuation_account_id
         )
@@ -831,3 +843,13 @@ class StockMove(models.Model):
                     _logger.debug(svl_value)
 
         return svl_values
+
+    def _get_dest_account(self, accounts_data):
+        if self.is_l10n_ro_record and self._is_internal_transit_in():
+            return accounts_data["stock_valuation"].id
+        return super()._get_dest_account(accounts_data)
+
+    def _get_src_account(self, accounts_data):
+        if self.is_l10n_ro_record and self._is_internal_transit_out():
+            return accounts_data["stock_valuation"].id
+        return super()._get_src_account(accounts_data)

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -70,8 +70,10 @@ class StockValuationLayer(models.Model):
             account = self.env["account.account"]
             svl = svl.with_company(svl.stock_move_id.company_id)
 
-            loc_dest = svl.stock_move_id.location_dest_id
-            loc_scr = svl.stock_move_id.location_id
+            (
+                loc_scr,
+                loc_dest,
+            ) = svl.stock_move_id._get_accounting_data_for_valuation_locations()
             account = (
                 svl.product_id.l10n_ro_property_stock_valuation_account_id
                 or svl.product_id.categ_id.property_stock_valuation_account_id
@@ -88,13 +90,8 @@ class StockValuationLayer(models.Model):
                 ):
                     account = loc_scr.l10n_ro_property_stock_valuation_account_id
             if svl.account_move_id and "internal" not in svl.l10n_ro_valued_type:
-                for aml in svl.account_move_id.line_ids.sorted(
-                    lambda layer: layer.account_id.code
-                ):
-                    if aml.account_id.code[0] in ["2", "3"]:
-                        if round(aml.balance, 2) == round(svl.value, 2):
-                            account = aml.account_id
-                            break
+                account = svl._l10n_ro_get_svl_account_from_account_move(account)
+
             if svl._l10n_ro_can_use_invoice_line_account(account):
                 if (
                     svl.l10n_ro_valued_type in ("reception", "reception_return")
@@ -102,6 +99,18 @@ class StockValuationLayer(models.Model):
                 ):
                     account = svl.l10n_ro_invoice_line_id.account_id
             svl.l10n_ro_account_id = account
+
+    def _l10n_ro_get_svl_account_from_account_move(self, account):
+        # hook method pentru l10n_ro_stock_account_tracking_sale_transform
+        self.ensure_one()
+        for aml in self.account_move_id.line_ids.sorted(
+            lambda layer: layer.account_id.code
+        ):
+            if aml.account_id.code[0] in ["2", "3"]:
+                if round(aml.balance, 2) == round(self.value, 2):
+                    account = aml.account_id
+                    break
+        return account
 
     # hook method for reception in progress
     def _l10n_ro_can_use_invoice_line_account(self, account):

--- a/l10n_ro_stock_account_tracking/__manifest__.py
+++ b/l10n_ro_stock_account_tracking/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting tracking",
-    "version": "17.0.1.6.0",
+    "version": "17.0.1.7.0",
     "category": "Localization",
     "summary": "Romania - Stock Accounting",
     "author": "NextERP Romania,"

--- a/l10n_ro_stock_account_tracking/init_hook.py
+++ b/l10n_ro_stock_account_tracking/init_hook.py
@@ -315,6 +315,11 @@ def store_svl_lot_and_locations(cr):
         )
         cr.execute(
             """
+                ALTER TABLE stock_valuation_layer
+                ADD COLUMN l10n_ro_location_eval_id integer""",
+        )
+        cr.execute(
+            """
             WITH sub as (
                 SELECT
                     svl.id as svl_id,
@@ -337,4 +342,28 @@ def store_svl_lot_and_locations(cr):
                 l10n_ro_location_dest_id = sub.location_dest_id
             FROM sub
             WHERE sub.svl_id = svl.id""",
+        )
+
+        # initializare svl.l10n_ro_location_eval_id
+        # setez l10n_ro_location_eval_id doar pe svl-urile cu quantity diferit de 0
+        # apoi svl-urile cu quantity = 0 din svl.stock_valuation_layer_id
+        cr.execute(
+            """
+            UPDATE stock_valuation_layer
+            SET l10n_ro_location_eval_id = CASE
+                    WHEN quantity > 0 THEN l10n_ro_location_dest_id
+                    WHEN quantity < 0 THEN l10n_ro_location_id
+                END
+            WHERE quantity != 0;
+            """
+        )
+
+        # valuation-uri landed cost, quantity = 0
+        cr.execute(
+            """
+            UPDATE stock_valuation_layer svl_lc
+            SET l10n_ro_location_eval_id = svl.l10n_ro_location_eval_id
+            FROM stock_valuation_layer svl
+            WHERE svl_lc.stock_valuation_layer_id = svl.id AND svl_lc.quantity = 0;
+            """
         )

--- a/l10n_ro_stock_account_tracking/migrations/17.0.1.7.0/pre-migration.py
+++ b/l10n_ro_stock_account_tracking/migrations/17.0.1.7.0/pre-migration.py
@@ -1,0 +1,43 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    if not openupgrade.column_exists(
+        cr, "stock_valuation_layer", "l10n_ro_location_eval_id"
+    ):
+        # initializare svl.l10n_ro_location_eval_id
+        openupgrade.logged_query(
+            cr,
+            """
+            ALTER TABLE stock_valuation_layer
+            ADD COLUMN l10n_ro_location_eval_id integer""",
+        )
+
+        # setez l10n_ro_location_eval_id doar pe svl-urile cu quantity diferit de 0
+        # apoi svl-urile cu quantity = 0 din svl.stock_valuation_layer_id
+        openupgrade.logged_query(
+            cr,
+            """
+            UPDATE stock_valuation_layer
+            SET l10n_ro_location_eval_id = CASE
+                    WHEN quantity > 0 THEN l10n_ro_location_dest_id
+                    WHEN quantity < 0 THEN l10n_ro_location_id
+                END
+            WHERE quantity != 0;
+            """,
+        )
+
+        # valuation-uri landed cost
+        openupgrade.logged_query(
+            cr,
+            """
+            UPDATE stock_valuation_layer svl_lc
+            SET l10n_ro_location_eval_id = svl.l10n_ro_location_eval_id
+            FROM stock_valuation_layer svl
+            WHERE svl_lc.stock_valuation_layer_id = svl.id AND svl_lc.quantity = 0;
+            """,
+        )

--- a/l10n_ro_stock_account_tracking/models/stock_move.py
+++ b/l10n_ro_stock_account_tracking/models/stock_move.py
@@ -15,6 +15,17 @@ class StockMove(models.Model):
     _name = "stock.move"
     _inherit = ["stock.move", "l10n.ro.mixin"]
 
+    def _get_accounting_data_for_valuation_locations(self):
+        # returneaza locatiile de pe stock.move.line
+        # in cazul in care am locatie parinte (internal), cu mai multe locatii copil
+        # si locatiile copil au conturi pe ele
+        sml_location_ids = self.move_line_ids.mapped("location_id")
+        sml_location_dest_ids = self.move_line_ids.mapped("location_dest_id")
+        if len(sml_location_ids) == 1 and len(sml_location_dest_ids) == 1:
+            return (sml_location_ids, sml_location_dest_ids)
+
+        return (self.location_id, self.location_dest_id)
+
     def _get_price_unit(self):
         # se caculeaza preturl cu functia standard
         price_unit = super()._get_price_unit()
@@ -311,7 +322,9 @@ class StockMove(models.Model):
             move = move.with_context(standard=True, valued_type="internal_transfer")
             move = move.with_company(move.company_id.id)
 
-            valued_move_lines = move.move_line_ids
+            valued_move_lines = move.move_line_ids.filtered(
+                lambda ml: not ml._should_exclude_for_valuation()
+            )
             for valued_move_line in valued_move_lines:
                 move = move.with_context(stock_move_line_id=valued_move_line)
                 valued_quantity = valued_move_line.product_uom_id._compute_quantity(

--- a/l10n_ro_stock_account_tracking/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account_tracking/models/stock_valuation_layer.py
@@ -26,6 +26,13 @@ class StockValuationLayer(models.Model):
         index=True,
         string="Romania - Destination Location",
     )
+    l10n_ro_location_eval_id = fields.Many2one(
+        "stock.location",
+        compute="_compute_l10n_ro_svl_locations_lot",
+        store=True,
+        index=True,
+        string="Valuation Location",
+    )
     l10n_ro_lot_ids = fields.Many2many(
         "stock.lot",
         compute="_compute_l10n_ro_svl_locations_lot",
@@ -69,6 +76,21 @@ class StockValuationLayer(models.Model):
             svl.l10n_ro_lot_ids = (
                 record.lot_id if "lot_id" in record._fields else record.lot_ids
             )
+            svl.l10n_ro_location_eval_id = self.env["stock.location"]
+            if svl.quantity > 0.0:
+                svl.l10n_ro_location_eval_id = svl.l10n_ro_location_dest_id
+            elif svl.quantity < 0.0:
+                svl.l10n_ro_location_eval_id = svl.l10n_ro_location_id
+            elif svl.stock_valuation_layer_id:
+                svl.l10n_ro_location_eval_id = (
+                    svl.stock_valuation_layer_id.l10n_ro_location_eval_id
+                )
+            else:
+                svl.l10n_ro_location_eval_id = (
+                    svl.l10n_ro_location_id
+                    if svl.l10n_ro_location_id.usage == "internal"
+                    else svl.l10n_ro_location_dest_id
+                )
 
     def _compute_l10n_ro_svl_tracking(self):
         for s in self:

--- a/l10n_ro_stock_account_tracking/views/stock_valuation_layer_views.xml
+++ b/l10n_ro_stock_account_tracking/views/stock_valuation_layer_views.xml
@@ -13,6 +13,7 @@
                 />
                 <field name="l10n_ro_location_id" />
                 <field name="l10n_ro_location_dest_id" />
+                <field name="l10n_ro_location_eval_id" />
                 <field name="l10n_ro_lot_ids" widget="many2many_tags" />
             </xpath>
             <xpath expr="//field[@name='account_move_id']" position="after">


### PR DESCRIPTION
- adaugare camp l10n_ro_location_eval_id pe svl (calculat in fct de quantity, si poate fi l10n_ro_location_id sau l10n_ro_location_dest_id), este util cand se grupeaza svl-urlile pe Valuation Location si se compara cu quant-urile (ar trebui sa fie egalitate)
- fix cand se face un transfer intern, dar este setat Owner pe picking, pe stock.move sau stock.move.line (nu trebuie sa se creeze svl internal_transfer)
- fix cand se fac transferuri din/in locatii tranzit, da eroarea (falsa) ca nu este setat pe categorie cont de Valuation Out Account 
- metode hook pentru un viitor modul (l10n_ro_stock_account_sale_transform) care sa faca transformare de conturi cand se vinde materie prima (fara sa se mai faca transfer intern Stock/Materii Prime -> Stock/Marfa)