### PR TITLE
Actualizează XPath-ul câmpului quantity în formularul returnărilor.

### DIFF
--- a/l10n_ro_stock_account_tracking/wizard/stock_picking_return_views.xml
+++ b/l10n_ro_stock_account_tracking/wizard/stock_picking_return_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_stock_return_picking_form" />
         <field name="arch" type="xml">
             <xpath
-                expr="//field[@name='product_return_moves']/tree/field[@name='quantity']"
+                expr="//field[@name='product_return_moves']/list/field[@name='quantity']"
                 position="after"
             >
                 <field name="l10n_ro_origin_ret_move_qty_warn" invisible="1" />


### PR DESCRIPTION
A fost corectat XPath-ul utilizat pentru câmpul `quantity` în XML, înlocuind tag-ul `tree` cu `list`. Această modificare asigură afișarea corectă a câmpului și conformitatea definiției cu structura actualizată a Odoo.