### PR TITLE
[18.0][IMP] Corectează formatul codului poștal pentru România.

### DIFF
--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -21,6 +21,8 @@ class Partner(models.Model):
     @api.onchange("zip")
     def onchange_zip(self):
         if self.zip and self.country_id.code == "RO":
+            if len(self.zip) == 5:
+                self.zip = '0' + self.zip
             state_b = self.env.ref("base.RO_B")
 
             domain = [

--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -22,7 +22,7 @@ class Partner(models.Model):
     def onchange_zip(self):
         if self.zip and self.country_id.code == "RO":
             if len(self.zip) == 5:
-                self.zip = '0' + self.zip
+                self.zip = "0" + self.zip
             state_b = self.env.ref("base.RO_B")
 
             domain = [


### PR DESCRIPTION
Adaugă o verificare suplimentară în metoda `onchange_zip` pentru a prefixa codurile poștale cu 0 atunci când acestea au 5 caractere. Această corectare asigură conformitatea cu formatul standard al codurilor poștale din România.