### PR TITLE
[18.0][FIX] Corectează actualizarea orașului pe baza codului poștal.

### DIFF
--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -47,7 +47,7 @@ class Partner(models.Model):
                     "06": "l10n_ro_city.RO_179196",  # Sector 6
                 }
                 city = self.env.ref(mapping[self.zip[:2]])
-                if self.state_id != state_b:
+                if self.state_id != state_b and 'skip_ro_vat_change' not in self.env.context:
                     raise UserError(
                         _(
                             f"The city {city.name} doesn't match the"
@@ -62,13 +62,10 @@ class Partner(models.Model):
                 city = self.env["res.city"].search(domain, limit=1)
 
             if city:
-                self.write(
-                    {
-                        "city_id": city.id,
-                        "city": city.name,
-                        "state_id": city.state_id.id,
-                    }
-                )
+                self.city = city.name
+                self.city_id = city
+                self.state = city.state_id
+
 
     @api.onchange("city_id")
     def _onchange_city_id(self):

--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -67,7 +67,7 @@ class Partner(models.Model):
             if city:
                 self.city = city.name
                 self.city_id = city
-                self.state = city.state_id
+                self.state_id = city.state_id
 
     @api.onchange("city_id")
     def _onchange_city_id(self):

--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -47,7 +47,10 @@ class Partner(models.Model):
                     "06": "l10n_ro_city.RO_179196",  # Sector 6
                 }
                 city = self.env.ref(mapping[self.zip[:2]])
-                if self.state_id != state_b and 'skip_ro_vat_change' not in self.env.context:
+                if (
+                    self.state_id != state_b
+                    and "skip_ro_vat_change" not in self.env.context
+                ):
                     raise UserError(
                         _(
                             f"The city {city.name} doesn't match the"
@@ -65,7 +68,6 @@ class Partner(models.Model):
                 self.city = city.name
                 self.city_id = city
                 self.state = city.state_id
-
 
     @api.onchange("city_id")
     def _onchange_city_id(self):


### PR DESCRIPTION
Revizuiește logica de actualizare pentru câmpurile `city`, `city_id` și `state`, utilizând atribute directe în loc de metoda `write`. De asemenea, adaugă o verificare suplimentară pentru contextul `skip_ro_vat_change`, evitând excepțiile nedorite în anumite cazuri.
In ANAF sunt intregistrate date gresite la codul postal ex: RO31176865