### PR TITLE
[19.0][IMP] Refactor locațiile companiei pentru consum și utilizare

### DIFF
--- a/l10n_ro_stock/__manifest__.py
+++ b/l10n_ro_stock/__manifest__.py
@@ -6,6 +6,7 @@
     "countries": ["ro"],
     "depends": ["stock", "l10n_ro_config"],
     "data": [
+        "data/stock_data.xml",
         "views/stock_warehouse_view.xml",
         "views/product_template_view.xml",
     ],

--- a/l10n_ro_stock/data/stock_data.xml
+++ b/l10n_ro_stock/data/stock_data.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <function model="res.company" name="create_missing_consume_location" />
+    <function model="res.company" name="create_missing_usage_location" />
+</odoo>

--- a/l10n_ro_stock/models/__init__.py
+++ b/l10n_ro_stock/models/__init__.py
@@ -1,3 +1,4 @@
+from . import res_company
 from . import stock_location
 from . import stock_warehouse
 from . import product_template

--- a/l10n_ro_stock/models/res_company.py
+++ b/l10n_ro_stock/models/res_company.py
@@ -1,0 +1,75 @@
+from odoo import api, fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    l10n_ro_usage_location_id = fields.Many2one(
+        "stock.location",
+        string="Usage Location",
+        readonly=True,
+        copy=False,
+        domain=[("usage", "=", "usage_giving")],
+    )
+    l10n_ro_consume_location_id = fields.Many2one(
+        "stock.location",
+        string="Consume Location",
+        readonly=True,
+        copy=False,
+        domain=[("usage", "=", "consume")],
+    )
+
+    @api.model
+    def create_missing_usage_location(self):
+        company_ids = self.env["res.company"].search(
+            [("l10n_ro_accounting", "=", True)]
+        )
+        companies_having_usage_loc = (
+            self.env["stock.location"]
+            .search([("usage", "=", "usage_giving")])
+            .mapped("company_id")
+        )
+        company_without_property = company_ids - companies_having_usage_loc
+        company_without_property._create_usage_location()
+
+    @api.model
+    def create_missing_consume_location(self):
+        company_ids = self.env["res.company"].search(
+            [("l10n_ro_accounting", "=", True)]
+        )
+        companies_having_consume_loc = (
+            self.env["stock.location"]
+            .search([("usage", "=", "consume")])
+            .mapped("company_id")
+        )
+        company_without_property = company_ids - companies_having_consume_loc
+        company_without_property._create_consume_location()
+
+    def _create_usage_location(self):
+        for company in self:
+            location = self.env["stock.location"].create(
+                {
+                    "name": self.env._("Usage"),
+                    "usage": "usage_giving",
+                    "company_id": company.id,
+                }
+            )
+            company.write({"l10n_ro_usage_location_id": location.id})
+
+    def _create_consume_location(self):
+        for company in self:
+            location = self.env["stock.location"].create(
+                {
+                    "name": self.env._("Consume"),
+                    "usage": "consume",
+                    "company_id": company.id,
+                }
+            )
+            company.write({"l10n_ro_consume_location_id": location.id})
+
+    def _create_per_company_locations(self):
+        res = super()._create_per_company_locations()
+        if self._check_is_l10n_ro_record():
+            self._create_usage_location()
+            self._create_consume_location()
+        return res

--- a/l10n_ro_stock/models/stock_warehouse.py
+++ b/l10n_ro_stock/models/stock_warehouse.py
@@ -10,12 +10,6 @@ class StockWarehouse(models.Model):
     _name = "stock.warehouse"
     _inherit = ["stock.warehouse", "l10n.ro.mixin"]
 
-    l10n_ro_wh_consume_loc_id = fields.Many2one(
-        "stock.location", string="Romania - Consume Location"
-    )
-    l10n_ro_wh_usage_loc_id = fields.Many2one(
-        "stock.location", string="Romania - Usage Giving Location"
-    )
     l10n_ro_consume_type_id = fields.Many2one(
         "stock.picking.type", string="Romania - Consume Type"
     )
@@ -23,40 +17,12 @@ class StockWarehouse(models.Model):
         "stock.picking.type", string="Romania - Usage Giving Type"
     )
 
-    def _get_locations_values(self, vals, code=False):
-        sub_locations = super()._get_locations_values(vals, code)
-        if self.env["res.company"]._check_is_l10n_ro_record(
-            company=vals.get("company_id")
-        ):
-            code = vals.get("code") or code or ""
-            code = code.replace(" ", "").upper()
-            company_id = vals.get(
-                "company_id", self.default_get(["company_id"])["company_id"]
-            )
-            sub_locations.update(
-                {
-                    "l10n_ro_wh_consume_loc_id": {
-                        "name": self.env._("Consume"),
-                        "active": True,
-                        "usage": "consume",
-                        "barcode": self._valid_barcode(code + "-CONSUME", company_id),
-                    },
-                    "l10n_ro_wh_usage_loc_id": {
-                        "name": self.env._("Usage"),
-                        "active": True,
-                        "usage": "usage_giving",
-                        "barcode": self._valid_barcode(code + "-USAGE", company_id),
-                    },
-                }
-            )
-        return sub_locations
-
     def _get_picking_type_update_values(self):
         res = super()._get_picking_type_update_values()
         if self.is_l10n_ro_record:
-            if self.l10n_ro_wh_consume_loc_id:
+            if self.company_id.l10n_ro_consume_location_id:
                 res.update({"l10n_ro_consume_type_id": {}})
-            if self.l10n_ro_wh_usage_loc_id:
+            if self.company_id.l10n_ro_usage_location_id:
                 res.update({"l10n_ro_usage_type_id": {}})
         return res
 
@@ -65,7 +31,9 @@ class StockWarehouse(models.Model):
             max_sequence
         )
         if self.is_l10n_ro_record:
-            if self.l10n_ro_wh_consume_loc_id:
+            usage_location = self.company_id.l10n_ro_usage_location_id
+            consume_location = self.company_id.l10n_ro_consume_location_id
+            if consume_location:
                 create_data.update(
                     {
                         "l10n_ro_consume_type_id": {
@@ -74,7 +42,7 @@ class StockWarehouse(models.Model):
                             "use_create_lots": True,
                             "use_existing_lots": False,
                             "default_location_src_id": self.lot_stock_id.id,
-                            "default_location_dest_id": self.l10n_ro_wh_consume_loc_id.id,  # noqa
+                            "default_location_dest_id": consume_location.id,  # noqa
                             "sequence": max_sequence + 6,
                             "barcode": self.code.replace(" ", "").upper() + "-CONSUME",
                             "sequence_code": "CONS",
@@ -82,7 +50,7 @@ class StockWarehouse(models.Model):
                         }
                     }
                 )
-            if self.l10n_ro_wh_usage_loc_id:
+            if usage_location:
                 create_data.update(
                     {
                         "l10n_ro_usage_type_id": {
@@ -91,7 +59,7 @@ class StockWarehouse(models.Model):
                             "use_create_lots": True,
                             "use_existing_lots": False,
                             "default_location_src_id": self.lot_stock_id.id,
-                            "default_location_dest_id": self.l10n_ro_wh_usage_loc_id.id,  # noqa
+                            "default_location_dest_id": usage_location.id,  # noqa
                             "sequence": max_sequence + 7,
                             "barcode": self.code.replace(" ", "").upper() + "-USAGE",
                             "sequence_code": "USAGE",

--- a/l10n_ro_stock/tests/test_stock_warehouse_creation.py
+++ b/l10n_ro_stock/tests/test_stock_warehouse_creation.py
@@ -13,12 +13,15 @@ class TestStockWarehouseCreation(AccountTestInvoicingCommon):
         super().setUpClass()
         cls.env.company.anglo_saxon_accounting = True
         cls.env.company.l10n_ro_accounting = True
+        cls.env.company._create_usage_location()
+        cls.env.company._create_consume_location()
 
     def setUp(self):
         super().setUp()
         self.warehouse_obj = self.env["stock.warehouse"]
 
     def test_warehouse_creation(self):
+        company = self.env.company
         warehouse = self.warehouse_obj.create(
             {
                 "name": "Warehouse Romania",
@@ -26,27 +29,26 @@ class TestStockWarehouseCreation(AccountTestInvoicingCommon):
                 "company_id": self.env.company.id,
             }
         )
-        self.assertTrue(warehouse.l10n_ro_wh_consume_loc_id)
-        self.assertTrue(warehouse.l10n_ro_wh_usage_loc_id)
+
         self.assertTrue(warehouse.l10n_ro_consume_type_id)
         self.assertTrue(warehouse.l10n_ro_usage_type_id)
 
         wh_stock_loc = warehouse.lot_stock_id
-        wh_consume_loc = warehouse.l10n_ro_wh_consume_loc_id
-        wh_usage_loc = warehouse.l10n_ro_wh_usage_loc_id
+        consume_loc = company.l10n_ro_consume_location_id
+        usage_loc = company.l10n_ro_usage_location_id
         consume_type = warehouse.l10n_ro_consume_type_id
         usage_type = warehouse.l10n_ro_usage_type_id
 
-        self.assertTrue(wh_consume_loc.usage, "consume")
-        self.assertTrue(wh_usage_loc.usage, "usage_giving")
+        self.assertTrue(consume_loc.usage, "consume")
+        self.assertTrue(usage_loc.usage, "usage_giving")
 
         self.assertTrue(consume_type.code, "internal")
         self.assertTrue(consume_type.default_location_src_id, wh_stock_loc)
-        self.assertTrue(consume_type.default_location_dest_id, wh_consume_loc)
+        self.assertTrue(consume_type.default_location_dest_id, consume_loc)
 
         self.assertTrue(usage_type.code, "internal")
         self.assertTrue(usage_type.default_location_src_id, wh_stock_loc)
-        self.assertTrue(usage_type.default_location_dest_id, wh_usage_loc)
+        self.assertTrue(usage_type.default_location_dest_id, usage_loc)
 
     def test_warehouse_rename(self):
         warehouse = self.warehouse_obj.create(

--- a/l10n_ro_stock/views/stock_warehouse_view.xml
+++ b/l10n_ro_stock/views/stock_warehouse_view.xml
@@ -5,10 +5,6 @@
         <field name="model">stock.warehouse</field>
         <field name="inherit_id" ref="stock.view_warehouse" />
         <field name="arch" type="xml">
-            <field name="wh_output_stock_loc_id" position="after">
-                <field name="l10n_ro_wh_consume_loc_id" readonly="1" />
-                <field name="l10n_ro_wh_usage_loc_id" readonly="1" />
-            </field>
             <field name="out_type_id" position="after">
                 <field name="l10n_ro_consume_type_id" readonly="1" />
                 <field name="l10n_ro_usage_type_id" readonly="1" />


### PR DESCRIPTION
Elimină locațiile legate de depozit și le mută la nivel de companie. Adaugă metode pentru crearea locațiilor lipsă și actualizează logica de configurare a tipurilor de picking pentru a le utiliza.