### PR TITLE
[17.0][FIX] Schimbă logica metodei `_get_move_line_quantity`

### DIFF
--- a/l10n_ro_stock_picking_valued_report/models/stock_move_line.py
+++ b/l10n_ro_stock_picking_valued_report/models/stock_move_line.py
@@ -44,7 +44,7 @@ class StockMoveLine(models.Model):
     )
 
     def _get_move_line_quantity(self):
-        return self.quantity or self.reserved_qty
+        return self.quantity
 
     @api.depends(
         "l10n_ro_sale_line_id",


### PR DESCRIPTION
Elimină utilizarea câmpului `reserved_qty` în metoda `_get_move_line_quantity`, utilizând doar valoarea din `quantity`. Modificarea simplifică logica și previne potențiale inconsistențe.