### PR TITLE
[19.0][FIX] Eliminare dependință de biblioteca `zeep`

### DIFF
--- a/l10n_ro_partner_create_by_vat/__manifest__.py
+++ b/l10n_ro_partner_create_by_vat/__manifest__.py
@@ -19,10 +19,4 @@
         "security/ir.model.access.csv",
     ],
     "maintainers": ["feketemihai"],
-    "external_dependencies": {
-        "python": ["zeep==4.3.2"],
-        "apt": {
-            "zeep": "python3-zeep",
-        },
-    },
 }

--- a/l10n_ro_partner_create_by_vat/tests/test_create_partner_by_vat.py
+++ b/l10n_ro_partner_create_by_vat/tests/test_create_partner_by_vat.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 NextERP Romania
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import logging
+
 from unittest.mock import Mock, patch
 
 import requests
@@ -12,8 +12,6 @@ from odoo.tests import Form, tagged
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 from .anaf_data import ANAF_TEST_DATA
-
-logging.getLogger("zeep").setLevel(logging.ERROR)
 
 
 @tagged("post_install", "-at_install")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # generated from manifests external_dependencies
 num2words>=0.5.8
 python-dateutil
-zeep==4.3.2


### PR DESCRIPTION
S-a eliminat utilizarea bibliotecii `zeep`, precum și referințele aferente din `requirements.txt` și `manifest`. Modificarea reduce dependențele externe și simplifică gestionarea proiectului.