### PR TITLE
[19.0][FIX] replaced null with x.l10n_ro_account_id in stock sheet report

### DIFF
--- a/l10n_ro_stock_report/report/stock_report.py
+++ b/l10n_ro_stock_report/report/stock_report.py
@@ -261,7 +261,7 @@ class StorageSheet(models.TransientModel):
             SELECT %(report)s as report_id, x.product_id as product_id,
                 COALESCE(sum(x.amount), 0) as amount_initial,
                 COALESCE(sum(x.quantity), 0) as quantity_initial,
-                NULL::int as account_id,
+                x.l10n_ro_account_id::int as account_id,
                 %(datetime_from)s::timestamp without time zone  as date_time,
                 %(date_from)s::date as date,
                 %(reference)s as reference,
@@ -316,7 +316,7 @@ class StorageSheet(models.TransientModel):
                 COALESCE(sum(x.amount), 0) as amount_final,
                 COALESCE(sum(x.quantity), 0) as quantity_final,
 
-                NULL::int as account_id,
+                x.l10n_ro_account_id::int as account_id,
                 %(datetime_to)s::timestamp without time zone as date_time,
                 %(date_to)s::date as date,
                 %(reference)s as reference,
@@ -376,7 +376,7 @@ class StorageSheet(models.TransientModel):
                     THEN COALESCE(sum(sm.value),0) / NULLIF(sum(sm.quantity),0)
                 ELSE 0
             END as unit_price_in,
-             NULL::int as account_id,
+             x.l10n_ro_account_id::int as account_id,
              NULL::int as invoice_id,
             sm.date as date_time,
             date_trunc('day', sm.date at time zone 'utc' at time zone %(tz)s) as date,
@@ -424,7 +424,7 @@ class StorageSheet(models.TransientModel):
                     THEN COALESCE(sum(sm.value),0) / NULLIF(sum(sm.quantity),0)
                 ELSE 0
             END as unit_price_out,
-            NULL::int as account_id,
+            x.l10n_ro_account_id::int as account_id,
             NULL::int as invoice_id,
             sm.date as date_time,
             date_trunc('day', sm.date at time zone 'utc' at time zone %(tz)s) as date,


### PR DESCRIPTION
Due to adding l10n_ro_account_id in stock.move I modified the sql in stock sheet report to also have this account there.