### PR TITLE
[17.0][IMP] Adaugă suport pentru validarea unicității `VAT` și `NRC`

### DIFF
--- a/l10n_ro_partner_unique/__init__.py
+++ b/l10n_ro_partner_unique/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/l10n_ro_partner_unique/models/res_partner.py
+++ b/l10n_ro_partner_unique/models/res_partner.py
@@ -11,32 +11,58 @@ class ResPartner(models.Model):
 
     def _get_vat_nrc_constrain_domain(self):
         self.ensure_one()
-        if self.is_l10n_ro_record:
-            domain = [
-                ("company_id", "=", self.company_id.id if self.company_id else False),
-                ("parent_id", "=", False),
-                ("vat", "=", self.vat),
+        vat = (self.vat or "").strip().upper()
+        nrc = (self.nrc or "").strip().upper() if self.nrc else ""
+
+        vat_2 = vat.replace("RO", "")
+        vat_1 = "RO" + vat_2
+
+        # citiere paramentru legat de uniticatea VAT sau unitictate de CUI+NRC
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        vat_nrc_unique = get_param(
+            "l10n_ro_partner_unique.vat_nrc_unique", default="vat"
+        )
+
+        domain = [
+            ("company_id", "=", self.company_id.id if self.company_id else False),
+            ("parent_id", "=", False),
+            ("id", "!=", self.id),
+            ("is_company", "=", True),
+        ]
+
+        if vat_nrc_unique == "vat":
+            domain += [
                 "|",
-                ("nrc", "=", self.nrc),
+                ("vat", "=ilike", vat_1),
+                ("vat", "=ilike", vat_2),
+            ]
+        if vat_nrc_unique == "vat_nrc":
+            domain += [
+                "&",
+                "|",
+                ("vat", "=ilike", vat_1),
+                ("vat", "=ilike", vat_2),
+                "|",
+                ("nrc", "=ilike", nrc),
                 ("nrc", "=", False),
             ]
-        else:
-            domain = []
+
         return domain
 
-    @api.constrains("vat", "nrc")
+    @api.constrains("vat", "nrc", "is_company")
     def _check_vat_nrc_unique(self):
-        for record in self:
+        if self.env.context.get("partner_merge"):
+            return True
+        for record in self.filtered("is_company"):
+            if record.parent_id:
+                continue
             if record.vat and record.is_l10n_ro_record:
                 domain = record._get_vat_nrc_constrain_domain()
-                found = self.env["res.partner"].search(domain)
-                if len(found) > 1:
+                if self.env["res.partner"].search(domain, limit=1):
                     raise ValidationError(
                         _(
-                            "The VAT and NRC pair (%(vat)s, %(nrc)s) must be "
-                            "unique ids=%(ids)s!",
+                            "The VAT and NRC pair (%(vat)s, %(nrc)s unique!",
                             vat=record.vat,
                             nrc=record.nrc,
-                            ids=found.ids,
                         )
                     )

--- a/l10n_ro_partner_unique/models/res_partner.py
+++ b/l10n_ro_partner_unique/models/res_partner.py
@@ -56,7 +56,7 @@ class ResPartner(models.Model):
         for record in self.filtered("is_company"):
             if record.parent_id:
                 continue
-            if record.vat and record.is_l10n_ro_record:
+            if record.vat and record.country_id.code == "RO":
                 domain = record._get_vat_nrc_constrain_domain()
                 if self.env["res.partner"].search(domain, limit=1):
                     raise ValidationError(

--- a/l10n_ro_partner_unique/tests/test_vat_nrc_unique.py
+++ b/l10n_ro_partner_unique/tests/test_vat_nrc_unique.py
@@ -15,18 +15,84 @@ class TestVatUnique(AccountTestInvoicingCommon):
         super().setUpClass(chart_template_ref="ro")
         cls.env.company.l10n_ro_accounting = True
         cls.partner = cls.env["res.partner"].create(
-            {"name": "Test partner", "vat": "RO30834857", "nrc": "J35/2622/2012"}
+            {
+                "name": "Test partner",
+                "vat": "RO30834857",
+                "nrc": "J35/2622/2012",
+                "is_company": True,
+            }
+        )
+
+    def test_duplicated_vat_nrc_creation(self):
+        """
+        Test if it is possible to create two partners with the same vat
+        """
+        set_para = self.env["ir.config_parameter"].sudo().set_param
+        set_para("l10n_ro_partner_unique.vat_nrc_unique", "vat_nrc")
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Second partner",
+                    "vat": "RO30834857",
+                    "nrc": "J35/2622/2012",
+                    "is_company": True,
+                }
+            )
+
+        self.env["res.partner"].create(
+            {
+                "name": "Second partner",
+                "vat": "RO30834857",
+                "nrc": "J2012002622359",
+                "is_company": True,
+            }
         )
 
     def test_duplicated_vat_creation(self):
-        """Test creation of partner."""
+        """
+        Test if it is possible to create two partners with the same vat
+        """
+        set_para = self.env["ir.config_parameter"].sudo().set_param
+        set_para("l10n_ro_partner_unique.vat_nrc_unique", "vat")
         with self.assertRaises(ValidationError):
             self.env["res.partner"].create(
-                {"name": "Second partner", "vat": "RO30834857", "nrc": "J35/2622/2012"}
+                {
+                    "name": "Second partner",
+                    "vat": "RO30834857",
+                    "nrc": "J35/2622/2012",
+                    "is_company": True,
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Second partner",
+                    "vat": "RO30834857",
+                    "nrc": "J2012002622359",
+                    "is_company": True,
+                }
+            )
+
+    def test_duplicated_vat_creation_without_prefix(self):
+        """
+        Test if it is possible to create two partners with the same
+         vat without prefix
+        """
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Second partner",
+                    "vat": "30834857",
+                    "nrc": "J35/2622/2012",
+                    "is_company": True,
+                }
             )
 
     def test_contact_vat_creation(self):
-        """Test creation of partner contacs."""
+        """
+        Test if it is possible to create a contact with the same vat
+        as the parent company
+        """
         self.env["res.partner"].create(
             {
                 "name": "Test partner 1 - child",
@@ -36,3 +102,31 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "nrc": "J35/2622/2012",
             }
         )
+        self.env["res.partner"].create(
+            {
+                "name": "Test partner 2 - child",
+                "parent_id": self.partner.id,
+                "is_company": True,
+                "vat": "RO30834857",
+                "nrc": "J35/2622/2012",
+            }
+        )
+
+
+
+    def test_duplicated_vat_creation_individual(self):
+        """
+        Test if is possible to create an individual with the same
+        vat as a company
+        """
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Second partner",
+                "vat": "RO30834857",
+                "nrc": "J35/2622/2012",
+                "is_company": False,
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            partner.is_company = True

--- a/l10n_ro_partner_unique/tests/test_vat_nrc_unique.py
+++ b/l10n_ro_partner_unique/tests/test_vat_nrc_unique.py
@@ -14,12 +14,14 @@ class TestVatUnique(AccountTestInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass(chart_template_ref="ro")
         cls.env.company.l10n_ro_accounting = True
+        cls.country_ro = cls.env.ref("base.ro")
         cls.partner = cls.env["res.partner"].create(
             {
                 "name": "Test partner",
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
                 "is_company": True,
+                "country_id": cls.country_ro.id
             }
         )
 
@@ -36,6 +38,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "RO30834857",
                     "nrc": "J35/2622/2012",
                     "is_company": True,
+                    "country_id": self.country_ro.id
                 }
             )
 
@@ -45,6 +48,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "vat": "RO30834857",
                 "nrc": "J2012002622359",
                 "is_company": True,
+                "country_id": self.country_ro.id
             }
         )
 
@@ -61,6 +65,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "RO30834857",
                     "nrc": "J35/2622/2012",
                     "is_company": True,
+                    "country_id": self.country_ro.id
                 }
             )
         with self.assertRaises(ValidationError):
@@ -70,6 +75,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "RO30834857",
                     "nrc": "J2012002622359",
                     "is_company": True,
+                    "country_id": self.country_ro.id
                 }
             )
 
@@ -85,6 +91,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "30834857",
                     "nrc": "J35/2622/2012",
                     "is_company": True,
+                    "country_id": self.country_ro.id
                 }
             )
 
@@ -100,6 +107,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "is_company": False,
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
+                "country_id": self.country_ro.id
             }
         )
         self.env["res.partner"].create(
@@ -109,10 +117,9 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "is_company": True,
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
+                "country_id": self.country_ro.id
             }
         )
-
-
 
     def test_duplicated_vat_creation_individual(self):
         """
@@ -125,8 +132,47 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
                 "is_company": False,
+                "country_id": self.country_ro.id
             }
         )
 
         with self.assertRaises(ValidationError):
             partner.is_company = True
+
+    def test_merge_two_partners_same_cui_without_country_then_set_ro(self):
+        """
+        Creează 2 parteneri companie fără țară, cu același CUI (VAT numeric, fără prefix RO),
+        apoi setează țara România și verifică faptul că pot fi uniți (merge) fără eroare.
+
+        Constrângerea de unicat este omisă în contextul de merge (partner_merge=True)
+        prin override-ul din wizard-ul local.
+        """
+        # Setăm regula de unicat pe CUI (VAT)
+        self.env["ir.config_parameter"].sudo().set_param(
+            "l10n_ro_partner_unique.vat_nrc_unique", "vat"
+        )
+
+        # 1) Creăm 2 companii fără țară, cu același CUI numeric (fără prefix RO)
+        p1 = self.env["res.partner"].create(
+            {
+                "name": "P1 Test",
+                "vat": "30834857",
+                "is_company": True,
+                "country_id": False,
+            }
+        )
+        p2 = self.env["res.partner"].create(
+            {
+                "name": "P2 Test",
+                "vat": "30834857",
+                "is_company": True,
+                "country_id": False,
+            }
+        )
+
+        ro = self.env.ref("base.ro")
+        p1.country_id = ro
+        p2.country_id = ro
+
+        wiz = self.env["base.partner.merge.automatic.wizard"].create({})
+        wiz._merge([p1.id, p2.id])

--- a/l10n_ro_partner_unique/tests/test_vat_nrc_unique.py
+++ b/l10n_ro_partner_unique/tests/test_vat_nrc_unique.py
@@ -21,7 +21,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
                 "is_company": True,
-                "country_id": cls.country_ro.id
+                "country_id": cls.country_ro.id,
             }
         )
 
@@ -38,7 +38,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "RO30834857",
                     "nrc": "J35/2622/2012",
                     "is_company": True,
-                    "country_id": self.country_ro.id
+                    "country_id": self.country_ro.id,
                 }
             )
 
@@ -48,7 +48,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "vat": "RO30834857",
                 "nrc": "J2012002622359",
                 "is_company": True,
-                "country_id": self.country_ro.id
+                "country_id": self.country_ro.id,
             }
         )
 
@@ -65,7 +65,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "RO30834857",
                     "nrc": "J35/2622/2012",
                     "is_company": True,
-                    "country_id": self.country_ro.id
+                    "country_id": self.country_ro.id,
                 }
             )
         with self.assertRaises(ValidationError):
@@ -75,7 +75,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "RO30834857",
                     "nrc": "J2012002622359",
                     "is_company": True,
-                    "country_id": self.country_ro.id
+                    "country_id": self.country_ro.id,
                 }
             )
 
@@ -91,7 +91,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                     "vat": "30834857",
                     "nrc": "J35/2622/2012",
                     "is_company": True,
-                    "country_id": self.country_ro.id
+                    "country_id": self.country_ro.id,
                 }
             )
 
@@ -107,7 +107,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "is_company": False,
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
-                "country_id": self.country_ro.id
+                "country_id": self.country_ro.id,
             }
         )
         self.env["res.partner"].create(
@@ -117,7 +117,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "is_company": True,
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
-                "country_id": self.country_ro.id
+                "country_id": self.country_ro.id,
             }
         )
 
@@ -132,7 +132,7 @@ class TestVatUnique(AccountTestInvoicingCommon):
                 "vat": "RO30834857",
                 "nrc": "J35/2622/2012",
                 "is_company": False,
-                "country_id": self.country_ro.id
+                "country_id": self.country_ro.id,
             }
         )
 
@@ -141,8 +141,9 @@ class TestVatUnique(AccountTestInvoicingCommon):
 
     def test_merge_two_partners_same_cui_without_country_then_set_ro(self):
         """
-        Creează 2 parteneri companie fără țară, cu același CUI (VAT numeric, fără prefix RO),
-        apoi setează țara România și verifică faptul că pot fi uniți (merge) fără eroare.
+        Creează 2 parteneri companie fără țară, cu același CUI
+        (VAT numeric, fără prefix RO),
+        apoi setează țara România și verifică faptul că pot fi uniți fără eroare.
 
         Constrângerea de unicat este omisă în contextul de merge (partner_merge=True)
         prin override-ul din wizard-ul local.

--- a/l10n_ro_partner_unique/wizard/__init__.py
+++ b/l10n_ro_partner_unique/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import base_partner_merge

--- a/l10n_ro_partner_unique/wizard/base_partner_merge.py
+++ b/l10n_ro_partner_unique/wizard/base_partner_merge.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class MergePartnerAutomatic(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        self = self.with_context(partner_merge=True)
+        return super()._merge(
+            partner_ids, dst_partner=dst_partner, extra_checks=extra_checks
+        )


### PR DESCRIPTION
Introdu o nouă configurare pentru validarea unicității pe baza doar a `VAT` sau combinată `VAT + NRC`. Modifică logica constrângerilor și adaugă teste suplimentare pentru scenarii variate, inclusiv parteneri individuali și companii.