### PR TITLE
[18.0][FIX]Corectează verificarea tipului de evaluare în stoc.

### DIFF
--- a/l10n_ro_nondeductible_vat/tests/common.py
+++ b/l10n_ro_nondeductible_vat/tests/common.py
@@ -28,6 +28,8 @@ class TestNondeductibleCommon(ValuationReconciliationTestCommon):
             account = cls.env["account.account.tag"].search(
                 [("name", "=", name)], limit=1
             )
+            if not account:
+                account = cls.env["account.account.tag"].create({"name": name})
             return account
 
         cls.account_vat_deductible = get_account("442600")

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -87,7 +87,9 @@ class StockValuationLayer(models.Model):
                     and loc_scr.l10n_ro_property_stock_valuation_account_id
                 ):
                     account = loc_scr.l10n_ro_property_stock_valuation_account_id
-            if svl.account_move_id and "internal" not in svl.l10n_ro_valued_type:
+            if svl.account_move_id and (
+                not svl.l10n_ro_valued_type or "internal" not in svl.l10n_ro_valued_type
+            ):
                 for aml in svl.account_move_id.line_ids.sorted(
                     lambda layer: layer.account_id.code
                 ):


### PR DESCRIPTION
Adaugă o verificare suplimentară pentru a trata cazurile în care `l10n_ro_valued_type` este nul sau inexistent. Această modificare îmbunătățește logica de manipulare a contabilizării valorilor stocului, prevenind posibilele erori.