### PR TITLE
[18.0][IMP] Adaugă tratarea stării de eroare și numărătoarea încercărilor de descărcare.

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -61,6 +61,7 @@ class MessageSPV(models.Model):
         ],
         default="draft",
     )
+    download_attempts = fields.Integer(string="Download Attempts", default=0)
     file_name = fields.Char()
     attachment_id = fields.Many2one("ir.attachment", string="Attachment")
     attachment_xml_id = fields.Many2one("ir.attachment", string="XML")
@@ -95,6 +96,8 @@ class MessageSPV(models.Model):
         session = requests.Session()
 
         for message in self.filtered(lambda m: not m.attachment_id):
+            if message.state == "error":
+                message.write({"state": "draft", "download_attempts": 0})
             # anaf_config = message.company_id.sudo()._l10n_ro_get_anaf_sync(
             #     scope="e-factura"
             # )
@@ -102,6 +105,8 @@ class MessageSPV(models.Model):
             #     raise UserError(_("ANAF configuration is missing."))
 
             # params = {"id": message.name}
+
+            message.write({"download_attempts": message.download_attempts + 1})
 
             response = self.env["l10n_ro_edi.document"]._request_ciusro_download_zip(
                 company=message.company_id,
@@ -112,7 +117,10 @@ class MessageSPV(models.Model):
             error = response.get("error", "")
 
             if error:
-                message.write({"error": error})
+                vals = {"error": error}
+                if message.download_attempts >= 3:
+                    vals["state"] = "error"
+                message.write(vals)
                 continue
             if message.message_type == "message":
                 info_message = message.check_anaf_message_xml(response["content"])

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -150,6 +150,7 @@ class MessageSPV(models.Model):
             zip_ref = zipfile.ZipFile(io.BytesIO(attachment.raw))
             xml_file = [f for f in zip_ref.namelist() if "semnatura" not in f]
             file_name = f"{message.request_id}.xml"
+            xml_bytes = False
             if xml_file:
                 file_name = xml_file[0]
                 xml_bytes = zip_ref.open(file_name)
@@ -459,6 +460,11 @@ class MessageSPV(models.Model):
                 message.write({"state": "error", "error": str(e)})
                 continue
 
+            _logger.info(
+                "Search existing invoice: ref=%s, partner=%s",
+                new_invoice.ref,
+                new_invoice.commercial_partner_id.id,
+            )
             exist_invoice = move_obj.search(
                 [
                     ("ref", "=", new_invoice.ref),
@@ -473,6 +479,7 @@ class MessageSPV(models.Model):
                 ],
                 limit=1,
             )
+            _logger.info("Exist invoice found: %s", exist_invoice.ids)
             if exist_invoice:
                 domain = [
                     ("res_model", "=", "account.move"),

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -61,7 +61,7 @@ class MessageSPV(models.Model):
         ],
         default="draft",
     )
-    download_attempts = fields.Integer(string="Download Attempts", default=0)
+    download_attempts = fields.Integer(default=0)
     file_name = fields.Char()
     attachment_id = fields.Many2one("ir.attachment", string="Attachment")
     attachment_xml_id = fields.Many2one("ir.attachment", string="XML")

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -30,11 +30,7 @@ class ResCompany(models.Model):
             domain = [
                 ("company_id", "=", company.id),
                 ("attachment_id", "=", False),
-                (
-                    "state",
-                    "=",
-                    "draft",
-                ),
+                ("state", "=", "draft"),
             ]
             messages = company.env["l10n.ro.message.spv"].search(
                 domain, limit=limit + 1

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -26,10 +26,15 @@ class ResCompany(models.Model):
 
         need_retrigger = False
         for company in ro_companies:
+            # procesăm doar mesajele în starea draft (care nu au erori sau nu sunt gata)
             domain = [
                 ("company_id", "=", company.id),
                 ("attachment_id", "=", False),
-                ("state", "=", "draft"),  # procesăm doar mesajele în starea draft (care nu au erori sau nu sunt gata)
+                (
+                    "state",
+                    "=",
+                    "draft",
+                ),
             ]
             messages = company.env["l10n.ro.message.spv"].search(
                 domain, limit=limit + 1

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -29,7 +29,7 @@ class ResCompany(models.Model):
             domain = [
                 ("company_id", "=", company.id),
                 ("attachment_id", "=", False),
-                ("state", "!=", "error"),  # nu mai procesăm în cron mesajele în eroare
+                ("state", "=", "draft"),  # procesăm doar mesajele în starea draft (care nu au erori sau nu sunt gata)
             ]
             messages = company.env["l10n.ro.message.spv"].search(
                 domain, limit=limit + 1

--- a/l10n_ro_message_spv/views/message_spv_view.xml
+++ b/l10n_ro_message_spv/views/message_spv_view.xml
@@ -52,6 +52,7 @@
                     decoration-success="state == 'done'"
                     decoration-info="state == 'downloaded'"
                     decoration-primary="state == 'invoice'"
+                    decoration-danger="state == 'error'"
                 />
             </list>
         </field>
@@ -112,6 +113,7 @@
                                 decoration-success="state == 'done'"
                                 decoration-info="state == 'downloaded'"
                                 decoration-primary="state == 'invoice'"
+                                decoration-danger="state == 'error'"
                             />
                         </group>
 
@@ -189,6 +191,11 @@
                         string="Draft"
                         name="draft"
                         domain="[('state', '=', 'draft')]"
+                    />
+                    <filter
+                        string="Error"
+                        name="error"
+                        domain="[('state', '=', 'error')]"
                     />
                     <filter
                         string="Done"


### PR DESCRIPTION


Adaugă decorări pentru starea de eroare în interfață și filtrează mesajele în funcție de starea acestora. Numără încercările de descărcare și marchează mesajele cu prea multe erori în stare „error” pentru a preveni procesările repetitive. Ajustează logica pentru a reinițializa mesajele înainte de a efectua o nouă încercare.