### PR TITLE
[18.0][FIX] l10n_ro_config: Use a valid BIC in tests

### DIFF
--- a/l10n_ro_config/tests/test_bank_account_print_report.py
+++ b/l10n_ro_config/tests/test_bank_account_print_report.py
@@ -38,7 +38,7 @@ class TestBankAccount(common.TransactionCase):
         cls.bank_test = cls.env["res.bank"].create(
             {
                 "name": "Bank 1",
-                "bic": "BIC 1",
+                "bic": "BIC00001",
             }
         )
 


### PR DESCRIPTION
BICs should have 8 or 11 characters, so the check when `account_payment_order` is installed fails:

https://github.com/OCA/bank-payment/blob/18.0/account_payment_order/models/res_bank.py#L12

so let's build a valid one in the tests for not having this problem.

@Tecnativa TT59807