### PR TITLE
[19.0][FIx]Corectare logică atașamente eFactura SPV

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -437,8 +437,13 @@ class MessageSPV(models.Model):
             new_invoice = new_invoice.with_context(
                 disable_onchange_name_predictive=True
             )
+
+            attachment_xml = message.attachment_xml_id.sudo()
+            files_data = new_invoice._to_files_data([attachment_xml])
+
+            new_invoice._extend_with_attachments(files_data)
             try:
-                new_invoice._extend_with_attachments(message.attachment_xml_id.sudo())
+                new_invoice._extend_with_attachments(files_data)
             except Exception as e:
                 message.write({"state": "error", "error": str(e)})
                 continue

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -441,7 +441,6 @@ class MessageSPV(models.Model):
             attachment_xml = message.attachment_xml_id.sudo()
             files_data = new_invoice._to_files_data([attachment_xml])
 
-            new_invoice._extend_with_attachments(files_data)
             try:
                 new_invoice._extend_with_attachments(files_data)
             except Exception as e:


### PR DESCRIPTION
Actualizată metoda de adăugare atașamente pentru a corecta gestiunea fișierelor în procesarea mesajelor SPV. S-a eliminat referința directă la `attachment_xml_id`, integrând conversia fișierelor printr-o funcție auxiliară pentru o gestionare mai robustă și uniformă.