### PR TITLE
[FIX] l10n_ro_message_spv: marchează facturile primite invoice_validated

### DIFF
--- a/l10n_ro_message_spv/models/account_move.py
+++ b/l10n_ro_message_spv/models/account_move.py
@@ -70,6 +70,15 @@ class AccountMove(models.Model):
         attachments += message_spv_ids.mapped("attachment_anaf_pdf_id")
         attachments += message_spv_ids.mapped("attachment_embedded_pdf_id")
         attachments.sudo().write({"res_id": False, "res_model": False})
+
+        # Documentul EDI (l10n_ro_edi.document) are invoice_id required, deci FK-ul
+        # e ON DELETE RESTRICT și blochează ștergerea facturii. Pentru facturile
+        # ciornă (duplicate descărcate de core din SPV) ștergem întâi documentele
+        # EDI, ca factura să poată fi eliminată fără intervenție manuală în DB.
+        draft_moves = self.filtered(lambda m: m.state == "draft")
+        if draft_moves and "l10n_ro_edi_document_ids" in draft_moves._fields:
+            draft_moves.l10n_ro_edi_document_ids.sudo().unlink()
+
         return super().unlink()
 
     # def _get_edi_decoder(self, file_data, new=False):

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -402,15 +402,23 @@ class MessageSPV(models.Model):
                             }
                         )
                 if not message.invoice_id.l10n_ro_edi_document_ids:
-                    if message.message_type != "error":
-                        state = "invoice_sent"
+                    if message.message_type in ("in_invoice", "in_receipt"):
+                        # Facturile primite se marchează invoice_validated, nu
+                        # invoice_sent. Core-ul l10n_ro_edi deduplică facturile
+                        # primite dupa l10n_ro_edi_state == 'invoice_validated';
+                        # cum starea e calculata din primul document EDI, daca
+                        # punem invoice_sent factura importata nu mai e gasita la
+                        # dedup, iar cronul de import o recreeaza (duplicat).
+                        edi_state = "invoice_validated"
+                    elif message.message_type == "error":
+                        edi_state = "invoice_refused"
                     else:
-                        state = "invoice_refused"
+                        edi_state = "invoice_sent"
 
                     self.env["l10n_ro_edi.document"].create(
                         {
                             "invoice_id": message.invoice_id.id,
-                            "state": state,
+                            "state": edi_state,
                         }
                     )
 

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -520,6 +520,40 @@ class TestMessageSPV(TestMessageSPV):
 
         self.assertEqual(message_spv.invoice_id.id, existing_invoice.id)
 
+    def test_received_invoice_edi_state_validated(self):
+        """Documentul EDI creat pentru o factură primită trebuie să fie
+        invoice_validated, nu invoice_sent.
+
+        Core-ul l10n_ro_edi deduplică facturile primite după
+        l10n_ro_edi_state == 'invoice_validated'; dacă punem invoice_sent,
+        factura importată nu mai e recunoscută la dedup și cronul o recreează
+        (sursa facturilor duplicate)."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+            }
+        )
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_VALIDATED",
+                "request_id": "REQ_VALIDATED",
+                "cif": "123",
+                "message_type": "in_invoice",
+                "partner_id": self.vendor.id,
+                "invoice_id": invoice.id,
+            }
+        )
+
+        # Nu există încă document EDI pe factură
+        self.assertFalse(invoice.l10n_ro_edi_document_ids)
+
+        message_spv.get_data_from_invoice()
+
+        self.assertTrue(invoice.l10n_ro_edi_document_ids)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids[0].state, "invoice_validated")
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_validated")
+
     def test_onchange_invoice_id(self):
         """Testează _onchange_invoice_id pentru diverse tipuri de facturi"""
         invoice = self.env["account.move"].create(

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -151,6 +151,32 @@ class TestMessageSPV(TestMessageSPV):
         self.assertFalse(attachment.res_id)
         self.assertFalse(attachment.res_model)
 
+    def test_unlink_draft_invoice_with_edi_document(self):
+        """O factură ciornă cu document EDI atașat trebuie să poată fi ștearsă.
+
+        Documentul EDI are invoice_id required (FK ON DELETE RESTRICT), ceea ce
+        altfel ar bloca ștergerea facturilor ciornă duplicate descărcate de core
+        din SPV. Override-ul de unlink șterge întâi documentele EDI."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+            }
+        )
+        edi_doc = self.env["l10n_ro_edi.document"].create(
+            {
+                "invoice_id": invoice.id,
+                "state": "invoice_validated",
+            }
+        )
+        self.assertEqual(invoice.state, "draft")
+        self.assertIn(edi_doc, invoice.l10n_ro_edi_document_ids)
+
+        invoice.unlink()
+
+        self.assertFalse(invoice.exists())
+        self.assertFalse(edi_doc.exists())
+
     def test_edi_transaction_tracking(self):
         """Testează câmpurile de urmărire a tranzacțiilor EDI"""
         # Creăm o factură


### PR DESCRIPTION
La crearea documentului EDI pentru o factură primită din SPV, modulul punea starea invoice_sent. Core-ul l10n_ro_edi deduplică facturile primite după l10n_ro_edi_state == 'invoice_validated' (account_move.py, fetch received bills). Cum l10n_ro_edi_state e calculat din primul document EDI, starea invoice_sent făcea ca factura deja importată să nu fie recunoscută la dedup, iar cronul de import o recrea — rezultând facturi duplicate.

Pentru mesajele in_invoice/in_receipt setăm acum invoice_validated, în acord cu starea pe care o pune core-ul la importul facturilor primite.