### PR TITLE
[19.0] ci: bump codecov-action to v6 for Node 24 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Update .pot files


### PR DESCRIPTION
## What

Bump `codecov/codecov-action` `v4` → `v6` in `.github/workflows/test.yml`.

## Why

`codecov-action@v4` internally pins `actions/github-script@v7.0.1`, which runs on the deprecated Node 20. GitHub Actions defaults to Node 24 starting 2026-06-16 and removes Node 20 from runners on 2026-09-16. `codecov-action@v6` bumps github-script to v8 (Node 24), clearing the deprecation warning.

## Note

This workflow is generated from `oca-addons-repo-template`. This PR fixes the rendered file directly to unblock CI on 19.0; ideally the same bump lands in the template so it propagates to all OCA repos on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)