### PR TITLE
[FIX] l10n_ro_message_spv: handle ANAF download error body, stop retry loop

### DIFF
--- a/l10n_ro_message_spv/models/ciusro_document.py
+++ b/l10n_ro_message_spv/models/ciusro_document.py
@@ -103,6 +103,23 @@ class L10nRoEdiDocument(models.Model):
             return result
 
         content = result["content"]
+        # ANAF poate răspunde cu HTTP 200 dar corp JSON de eroare (ex: limita de
+        # 10 descărcări/zi pe mesaj atinsă) în loc de arhiva ZIP. Tratăm explicit
+        # această condiție de business, fără a încerca parsarea ca ZIP și fără a
+        # o loga ca eroare de cod.
+        if content[:1] in (b"{", b"["):
+            try:
+                error_json = json.loads(content.decode("utf-8"))
+            except Exception:
+                error_json = None
+            if isinstance(error_json, dict) and error_json.get("eroare"):
+                _logger.warning(
+                    "ANAF download refused for id=%s: %s",
+                    key_download,
+                    error_json["eroare"],
+                )
+                return {"error": error_json["eroare"]}
+
         # E-Factura gives download response in ZIP format
         try:
             zip_ref = zipfile.ZipFile(io.BytesIO(content))

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -115,7 +115,11 @@ class MessageSPV(models.Model):
             error = response.get("error", "")
 
             if error:
-                message.write({"error": error})
+                # Marcăm mesajul ca eroare ca să nu fie reselectat la infinit de
+                # cron (domeniul exclude state="error"). ANAF limitează la 10
+                # descărcări/zi pe mesaj; reîncercarea oarbă doar epuizează cota
+                # și spamează logul. Re-descărcarea se face manual de pe mesaj.
+                message.write({"error": str(error), "state": "error"})
                 continue
             if message.message_type == "message":
                 info_message = message.check_anaf_message_xml(response["content"])

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -29,7 +29,11 @@ class ResCompany(models.Model):
 
         need_retrigger = False
         for company in ro_companies:
-            domain = [("company_id", "=", company.id), ("attachment_id", "=", False)]
+            domain = [
+                ("company_id", "=", company.id),
+                ("attachment_id", "=", False),
+                ("state", "!=", "error"),
+            ]
             messages = company.env["l10n.ro.message.spv"].search(
                 domain, limit=limit + 1
             )


### PR DESCRIPTION
## Problem

When the SPV `descarcare` endpoint hits the daily limit of **10 downloads per message**, ANAF replies with `HTTP 200` but a JSON error body instead of a ZIP archive:

```json
{"eroare":"S-au facut deja 10 descarcari la mesajul cu id_descarcare=... in cursul zilei","titlu":"Descarcare mesaj"}
```

Two issues result:

1. `_request_ciusro_download_zip` passes this body straight to `zipfile.ZipFile`, raising `BadZipFile` and logging an **ERROR** on every cron run.
2. On a failed download, `download_from_spv` only writes the error text without changing the message state. Since the download cron selects messages with no attachment (`attachment_id = False`), it re-picks the same messages forever, re-triggers itself, and keeps hammering ANAF — which keeps rejecting because the daily quota is already exhausted.

Observed in production as a tight loop of:

```
ERROR ... ciusro_document: Error File is not a zip file while parsing ZIP file: b'{"eroare":"S-au facut deja 10 descarcari ...
```

## Fix

- Detect a JSON error body before attempting ZIP parsing and return the ANAF message as a graceful error (logged as `WARNING`, not `ERROR`).
- Mark the message as `state="error"` when a download fails, so it is not retried automatically. It can still be re-downloaded manually from the message form (the **Download** button works because the message has no attachment).
- Exclude `state="error"` messages from the download cron domain, stopping the retry loop and the self-retrigger.

## Notes

No behavior change for the happy path (valid ZIP). Pre-commit (ruff / ruff format / pylint_odoo) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)