### PR TITLE
[FIX] l10n_ro_partner_unique: propagate partner_merge context to records

### DIFF
--- a/l10n_ro_partner_unique/models/res_partner.py
+++ b/l10n_ro_partner_unique/models/res_partner.py
@@ -51,6 +51,8 @@ class ResPartner(models.Model):
 
     @api.constrains("vat", "nrc", "is_company")
     def _check_vat_nrc_unique(self):
+        if self.env.context.get("partner_merge"):
+            return
         for record in self.filtered("is_company"):
             if record.parent_id:
                 continue

--- a/l10n_ro_partner_unique/wizard/__init__.py
+++ b/l10n_ro_partner_unique/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import base_partner_merge

--- a/l10n_ro_partner_unique/wizard/base_partner_merge.py
+++ b/l10n_ro_partner_unique/wizard/base_partner_merge.py
@@ -1,0 +1,14 @@
+from odoo import models
+
+
+class MergePartnerAutomatic(models.TransientModel):
+    _inherit = "base.partner.merge.automatic.wizard"
+
+    def _merge(self, partner_ids, dst_partner=None, extra_checks=True):
+        ctx = {"partner_merge": True}
+        partners = self.env["res.partner"].browse(partner_ids).with_context(**ctx)
+        if dst_partner:
+            dst_partner = dst_partner.with_context(**ctx)
+        return super()._merge(
+            partners.ids, dst_partner=dst_partner, extra_checks=extra_checks
+        )


### PR DESCRIPTION
## Summary

Fixed partner merge blocking due to VAT/NRC uniqueness constraint not seeing the `partner_merge` context flag.

Adds the missing wizard override for 19.0 and context check in the constraint.

## Changes

- Adds `wizard/base_partner_merge.py` to override merge method and propagate context
- Adds context check in uniqueness constraint to skip validation during merge

## Test Plan

- [ ] Merge two duplicate partners with identical VAT/NRC
- [ ] Verify the merge completes without ValidationError

🤖 Generated with Claude Code