### PR TITLE
[19.0][IMP] l10n_ro_nondeductible_vat: fix stock & support VAT on pay…

### DIFF
--- a/l10n_ro_nondeductible_vat/models/account_move.py
+++ b/l10n_ro_nondeductible_vat/models/account_move.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 NextERP Romania
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from collections import defaultdict
 from contextlib import contextmanager
 
 from odoo import models
@@ -13,8 +14,151 @@ class AccountMove(models.Model):
     _name = "account.move"
     _inherit = ["account.move", "l10n.ro.mixin"]
 
+    def _post(self, soft=True):
+        # Realize the deferred non-deductibility on the cash-basis entry that
+        # is generated at payment for VAT-on-payment taxes. On the invoice the
+        # split is skipped (see _get_sync_stack); it materializes here, when the
+        # VAT becomes deductible.
+        self._l10n_ro_split_cash_basis_non_deductible()
+        return super()._post(soft=soft)
+
+    def _l10n_ro_nd_fraction_from_origin(self, origin):
+        """Map {tax_id: non_deductible_fraction} for the on-payment taxes of
+        the originating invoice. The fraction is weighted by base, so several
+        product lines sharing the same tax with different deductibilities are
+        handled correctly (the cash-basis VAT is aggregated per tax)."""
+        nd_base = defaultdict(float)
+        total_base = defaultdict(float)
+        for line in origin.line_ids.filtered(
+            lambda line: line.display_type == "product"
+        ):
+            for tax in line.tax_ids.filtered(
+                lambda t: t.amount_type != "fixed"
+                and t.tax_exigibility == "on_payment"
+                and t.l10n_ro_is_nondeductible
+            ):
+                base = abs(line.balance)
+                total_base[tax.id] += base
+                nd_base[tax.id] += base * (1 - line.deductible_amount / 100.0)
+        return {
+            tax_id: nd_base[tax_id] / total_base[tax_id]
+            for tax_id in total_base
+            if total_base[tax_id] and nd_base[tax_id]
+        }
+
+    @staticmethod
+    def _l10n_ro_debit_credit(balance):
+        return (balance, 0.0) if balance > 0.0 else (0.0, -balance)
+
+    def _l10n_ro_split_cash_basis_non_deductible(self):
+        for move in self:
+            origin = move.tax_cash_basis_origin_move_id
+            if (
+                not origin
+                or move.state != "draft"
+                or not move.company_id.l10n_ro_accounting
+            ):
+                continue
+            nd_fraction = move._l10n_ro_nd_fraction_from_origin(origin)
+            if not nd_fraction:
+                continue
+            nd_account = move.company_id.l10n_ro_nondeductible_account_id
+            new_lines = []
+            to_delete = self.env["account.move.line"]
+            # Core matches the cash-basis counterpart lines by their sequence
+            # number, so keep the extra lines well outside that range.
+            next_sequence = max(move.line_ids.mapped("sequence") or [0]) + 100
+            for line in move.line_ids:
+                tax = line.tax_line_id
+                is_tax_line = (
+                    tax
+                    and tax.id in nd_fraction
+                    and line.tax_repartition_line_id.repartition_type == "tax"
+                )
+                base_taxes = line.tax_ids.filtered(lambda t, nd=nd_fraction: t.id in nd)
+                is_base_grid_line = not tax and line.tax_tag_ids and base_taxes
+                if not is_tax_line and not is_base_grid_line:
+                    continue
+
+                frac = nd_fraction[tax.id if is_tax_line else base_taxes[:1].id]
+                nd_balance = move.company_currency_id.round(line.balance * frac)
+                nd_amount_cur = line.currency_id.round(line.amount_currency * frac)
+                if not nd_balance and not nd_amount_cur:
+                    continue
+
+                if is_tax_line:
+                    # Move the non-deductible part of the VAT to expense.
+                    target_acc = nd_account or line.account_id
+                    nd_tags = line.tax_repartition_line_id.tag_ids.mapped(
+                        "l10n_ro_nondeductible_tag_id"
+                    )
+                    display_type = "non_deductible_tax_ro"
+                    name = self.env._("%(tax)s (non-deductible)", tax=tax.name)
+                else:
+                    # Reclass the corresponding base from the deductible grid
+                    # (e.g. 24 - TAX BASE) to the non-deductible one (24_2).
+                    target_acc = line.account_id
+                    nd_tags = line.tax_tag_ids.mapped("l10n_ro_nondeductible_tag_id")
+                    display_type = line.display_type
+                    name = line.name
+                if not nd_tags:
+                    continue
+
+                remaining_balance = line.balance - nd_balance
+                remaining_currency = line.amount_currency - nd_amount_cur
+                if move.company_currency_id.is_zero(
+                    remaining_balance
+                ) and line.currency_id.is_zero(remaining_currency):
+                    # Fully non-deductible: the deductible line vanishes.
+                    to_delete |= line
+                else:
+                    debit, credit = self._l10n_ro_debit_credit(remaining_balance)
+                    line.write(
+                        {
+                            "debit": debit,
+                            "credit": credit,
+                            "amount_currency": remaining_currency,
+                        }
+                    )
+                nd_debit, nd_credit = self._l10n_ro_debit_credit(nd_balance)
+                new_lines.append(
+                    Command.create(
+                        {
+                            "account_id": target_acc.id,
+                            "name": name,
+                            "display_type": display_type,
+                            "debit": nd_debit,
+                            "credit": nd_credit,
+                            "amount_currency": nd_amount_cur,
+                            "currency_id": line.currency_id.id,
+                            "partner_id": line.partner_id.id,
+                            "tax_tag_ids": [Command.set(nd_tags.ids)],
+                            "sequence": next_sequence,
+                        }
+                    )
+                )
+                next_sequence += 1
+            if new_lines:
+                move.write({"line_ids": new_lines})
+            if to_delete:
+                to_delete.with_context(dynamic_unlink=True).unlink()
+
+    def _l10n_ro_line_is_on_payment(self, line):
+        # VAT on payment (cash basis): non-deductibility is only realized when
+        # the invoice is paid, so it must NOT be split on the invoice itself.
+        # It is handled later on the cash-basis entry (see
+        # account.partial.reconcile).
+        return any(
+            tax.tax_exigibility == "on_payment"
+            for tax in line.tax_ids.filtered(lambda t: t.amount_type != "fixed")
+        )
+
     def _get_sync_stack(self, container):
         def has_l10n_ro_non_deductible_lines(move):
+            # Note: on-payment lines are intentionally kept here so the RO sync
+            # runs and removes the core non-deductible lines for them; the
+            # actual reversal is then skipped (deferred to the cash-basis
+            # entry) inside the sync creation loops.
             return move.state == "draft" and any(
                 move.line_ids.filtered(
                     lambda line: line.display_type == "product"
@@ -37,7 +181,59 @@ class AccountMove(models.Model):
                 ),
             )
         )
+        # Runs last (lowest priority => unwound last): the core non-deductible
+        # syncs (priorities 50/60) recreate the non-deductible lines after the
+        # RO syncs above, so for on-payment (cash basis) taxes we strip them
+        # here as the final step. Their non-deductibility is realized on the
+        # cash-basis entry generated at payment instead.
+        stack.append(
+            (45, self._l10n_ro_drop_on_payment_non_deductible_lines(container))
+        )
         return stack, update_containers
+
+    @contextmanager
+    def _l10n_ro_drop_on_payment_non_deductible_lines(self, container):
+        yield
+        to_delete = self.env["account.move.line"]
+        for move in container["records"]:
+            if move.state != "draft" or not move.company_id.l10n_ro_accounting:
+                continue
+            has_on_payment = move.line_ids.filtered(
+                lambda line, move=move: line.display_type == "product"
+                and line.deductible_amount < 100
+                and move._l10n_ro_line_is_on_payment(line)
+            )
+            if not has_on_payment:
+                continue
+            # A document cannot mix on-payment and on-invoice taxes, so every
+            # non-deductible line present here belongs to the deferred (cash
+            # basis) flow and must be stripped from the invoice. It is the core
+            # syncs (priorities 50/60) that recreate these after the RO syncs,
+            # hence this final cleanup step (lowest priority).
+            to_delete |= move.line_ids.filtered(
+                lambda line: line.display_type
+                in (
+                    "non_deductible_product",
+                    "non_deductible_product_total",
+                    "non_deductible_tax",
+                )
+            )
+        if to_delete:
+            to_delete.with_context(dynamic_unlink=True).unlink()
+
+    def _prepare_non_deductible_base_lines_for_taxes_computation_from_base_lines(
+        self, base_lines
+    ):
+        # Skip on-payment (cash basis) lines: their non-deductibility is
+        # deferred to the payment entry, so no non-deductible base/tax line
+        # should be anticipated on the invoice.
+        if self.company_id.l10n_ro_accounting:
+            base_lines = base_lines.filtered(
+                lambda line: not self._l10n_ro_line_is_on_payment(line)
+            )
+        return super()._prepare_non_deductible_base_lines_for_taxes_computation_from_base_lines(  # noqa: E501
+            base_lines
+        )
 
     def _get_l10n_ro_nd_repartition_lines(self, tax):
         self.ensure_one()
@@ -90,6 +286,8 @@ class AccountMove(models.Model):
                     float_compare(line.deductible_amount, 100, precision_rounding=2)
                     == 0
                 ):
+                    continue
+                if move._l10n_ro_line_is_on_payment(line):
                     continue
 
                 percentage = 1 - line.deductible_amount / 100
@@ -192,6 +390,8 @@ class AccountMove(models.Model):
                     float_compare(line.deductible_amount, 100, precision_rounding=2)
                     == 0
                 ):
+                    continue
+                if move._l10n_ro_line_is_on_payment(line):
                     continue
                 taxes = line.tax_ids.filtered(lambda t: t.amount_type != "fixed")
                 # Calculate 100% tax for this line

--- a/l10n_ro_nondeductible_vat/models/stock_move.py
+++ b/l10n_ro_nondeductible_vat/models/stock_move.py
@@ -39,6 +39,20 @@ class StockMove(models.Model):
             else:
                 s.l10n_ro_nondeductible_usage = False
 
+    def _create_account_move(self):
+        # When a stock move carries a non-deductible tax, the VAT was already
+        # deducted on reception, so the stock valuation entry must not generate
+        # a fresh deductible VAT line (and the balancing line that comes with
+        # it). The `l10n_ro_exclude_from_stock` context drops that tax line and
+        # keeps only the non-deductible reversal. This mirrors what
+        # stock.quant._apply_inventory does for inventory adjustments.
+        if any(
+            move.is_l10n_ro_record and move.l10n_ro_nondeductible_tax_id
+            for move in self
+        ):
+            self = self.with_context(l10n_ro_exclude_from_stock=True)
+        return super()._create_account_move()
+
     def _get_account_move_line_vals(self):
         # For nondeductible operation, add the taxes to the expense debit line
         res = super()._get_account_move_line_vals()

--- a/l10n_ro_nondeductible_vat/tests/__init__.py
+++ b/l10n_ro_nondeductible_vat/tests/__init__.py
@@ -1,5 +1,5 @@
 from . import common
-
-# from . import test_inventory
-# from . import test_consum
+from . import test_consum
+from . import test_inventory
 from . import test_invoice
+from . import test_vatp

--- a/l10n_ro_nondeductible_vat/tests/common.py
+++ b/l10n_ro_nondeductible_vat/tests/common.py
@@ -33,44 +33,6 @@ class TestNondeductibleCommon(TestROStockCommon, TestVATonpayment):
         cls.env.user.group_ids += cls.env.ref(
             "account.group_partial_purchase_deductibility"
         )
-        # Use standard Odoo tax (e.g. VAT 21% G)
-        cls.tax = cls.env["account.tax"].search(
-            [
-                ("type_tax_use", "=", "purchase"),
-                ("name", "=", "21% G"),
-                ("company_id", "=", cls.env.company.id),
-            ],
-            limit=1,
-        )
-        if not cls.tax:
-            raise Exception("Standard VAT 21% G tax not found for company!")
-        cls.vatp_tax = cls.env["account.tax"].search(
-            [
-                ("type_tax_use", "=", "purchase"),
-                ("name", "=", "21%"),
-                ("company_id", "=", cls.env.company.id),
-            ],
-            limit=1,
-        )
-        if not cls.vatp_tax:
-            raise Exception(
-                "Standard VAT on Payment VAT 21% tax not found for company!"
-            )
-        # Set l10n_ro_exclude_from_stock on tax repartition lines
-        for rep_line in cls.tax.repartition_line_ids.filtered(
-            lambda line: line.repartition_type == "tax"
-        ):
-            rep_line.l10n_ro_exclude_from_stock = True
-
-        # Set l10n_ro_nondeductible_tag_id on tax tags for non-deductible logic
-        cls.tag_base = _get_tags_by_name("24 - TAX BASE")
-        cls.tag_base_nd = cls.tag_base.copy({"name": "24_2 - TAX BASE"})
-        cls.tag_vat = _get_tags_by_name("24 - VAT")
-        cls.tag_vat_nd = cls.tag_vat.copy({"name": "24_2 - VAT"})
-        if cls.tag_base and cls.tag_base_nd:
-            cls.tag_base.l10n_ro_nondeductible_tag_id = cls.tag_base_nd.id
-        if cls.tag_vat and cls.tag_vat_nd:
-            cls.tag_vat.l10n_ro_nondeductible_tag_id = cls.tag_vat_nd.id
 
         cls.tax_account = get_account("442600")
         cls.payable_account = get_account("401100")
@@ -95,6 +57,41 @@ class TestNondeductibleCommon(TestROStockCommon, TestVATonpayment):
         )
         cls.env.company.account_cash_basis_base_account_id = vatp_base_account_id
         cls.vatp_base_account_id = vatp_base_account_id
+
+        # Set up the non-deductible tax grids: the deductible grids
+        # (24 - TAX BASE / 24 - VAT) point to their non-deductible
+        # counterparts (24_2 - ...). This is what flags a tax as
+        # `l10n_ro_is_nondeductible`.
+        cls.tag_base = _get_tags_by_name("24 - TAX BASE")
+        cls.tag_base_nd = cls.tag_base.copy({"name": "24_2 - TAX BASE"})
+        cls.tag_vat = _get_tags_by_name("24 - VAT")
+        cls.tag_vat_nd = cls.tag_vat.copy({"name": "24_2 - VAT"})
+        cls.tag_base.l10n_ro_nondeductible_tag_id = cls.tag_base_nd.id
+        cls.tag_vat.l10n_ro_nondeductible_tag_id = cls.tag_vat_nd.id
+
+        # Build dedicated non-deductible purchase taxes instead of relying
+        # on the taxes shipped with the chart of accounts (which are not
+        # configured for the Romanian non-deductible flow). The tax line
+        # is flagged `l10n_ro_exclude_from_stock` so that, on stock moves,
+        # it does not generate a deductible VAT entry (the VAT was already
+        # deducted on reception); only the non-deductible reversal is kept.
+        cls.tax = cls._l10n_ro_create_nondeductible_tax("21% Not deductible")
+        # VAT on payment non-deductible tax: identical configuration but
+        # with exigibility on payment (cash basis).
+        cls.vatp_tax = cls._l10n_ro_create_nondeductible_tax(
+            "21% Not deductible VATP",
+            tax_exigibility="on_payment",
+            cash_basis_account=cls.vatp_tax_account,
+        )
+        # A second VAT-on-payment tax sharing the very same grids (24 - TAX
+        # BASE / 24 - VAT). It is used on fully deductible lines, to check that
+        # a deductible and a non-deductible cash-basis tax can coexist on the
+        # same invoice without the split bleeding from one into the other.
+        cls.vatp_tax_deductible = cls._l10n_ro_create_nondeductible_tax(
+            "21% VATP",
+            tax_exigibility="on_payment",
+            cash_basis_account=cls.vatp_tax_account,
+        )
 
         # Create invoices
         cls.nd_invoice = cls.invoice_model.create(
@@ -147,3 +144,46 @@ class TestNondeductibleCommon(TestROStockCommon, TestVATonpayment):
         cls.env["stock.quant"].with_context(inventory_mode=True).create(
             inventory_vals
         ).action_apply_inventory()
+
+    @classmethod
+    def _l10n_ro_create_nondeductible_tax(
+        cls, name, tax_exigibility="on_invoice", cash_basis_account=None
+    ):
+        """Create a 21% purchase tax wired for the Romanian non-deductible
+        flow: base grid 24 - TAX BASE, tax grid 24 - VAT (both with a
+        non-deductible counterpart), and the tax repartition line flagged
+        `l10n_ro_exclude_from_stock`."""
+
+        def rep_lines():
+            return [
+                Command.create(
+                    {
+                        "repartition_type": "base",
+                        "factor_percent": 100,
+                        "tag_ids": [Command.set(cls.tag_base.ids)],
+                    }
+                ),
+                Command.create(
+                    {
+                        "repartition_type": "tax",
+                        "factor_percent": 100,
+                        "account_id": cls.tax_account.id,
+                        "tag_ids": [Command.set(cls.tag_vat.ids)],
+                        "l10n_ro_exclude_from_stock": True,
+                    }
+                ),
+            ]
+
+        vals = {
+            "name": name,
+            "type_tax_use": "purchase",
+            "amount_type": "percent",
+            "amount": 21.0,
+            "company_id": cls.env.company.id,
+            "tax_exigibility": tax_exigibility,
+            "invoice_repartition_line_ids": rep_lines(),
+            "refund_repartition_line_ids": rep_lines(),
+        }
+        if cash_basis_account:
+            vals["cash_basis_transition_account_id"] = cash_basis_account.id
+        return cls.env["account.tax"].create(vals)

--- a/l10n_ro_nondeductible_vat/tests/test_consum.py
+++ b/l10n_ro_nondeductible_vat/tests/test_consum.py
@@ -11,9 +11,109 @@ _logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
-class TestNonDeductibleInvoice(TestNondeductibleCommon):
+class TestNonDeductibleConsum(TestNondeductibleCommon):
     @TestNondeductibleCommon.setup_country("ro")
     def setUp(cls):
         super().setUp()
 
-    # Test consum nedeductibil
+    def _consume(self, percent="50", qty=1):
+        """Consume `qty` unit(s) (each valued 100) with the given
+        non-deductibility, returning the generated valuation account move."""
+        consume_location = self.env.company.l10n_ro_consume_location_id
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.product_fifo.id,
+                "product_uom_qty": qty,
+                "location_id": self.location.id,
+                "location_dest_id": consume_location.id,
+                "l10n_ro_nondeductible_percent": percent,
+                "l10n_ro_nondeductible_tax_id": self.tax.id,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move._set_quantity_done(qty)
+        move.picked = True
+        move._action_done()
+        return move.account_move_id
+
+    def _aml_signature(self, account_move):
+        return sorted(
+            (
+                line.account_id.code,
+                line.display_type,
+                line.debit,
+                line.credit,
+                tuple(sorted(line.tax_tag_ids.mapped("name"))),
+            )
+            for line in account_move.line_ids
+        )
+
+    def test_consum_50_percent(self):
+        """A 50% non-deductible consumption of goods valued 100 must not
+        generate a deductible VAT line (nor an automatic balancing line):
+        the VAT was already deducted on reception. Only the non-deductible
+        reversal (base + VAT) is booked."""
+        account_move = self._consume("50")
+
+        expected = sorted(
+            [
+                # Base consumption 607 = 100 / 371 = 100, no tax grid on the
+                # expense line (excluded from stock).
+                ("371000", "product", 0.0, 100.0, ()),
+                ("607000", "product", 100.0, 0.0, ()),
+                # Non-deductible base reversal: 50% moved from the deductible
+                # grid (24 - TAX BASE) to the non-deductible one.
+                ("607000", "non_deductible_product", -50.0, 0.0, ("24 - TAX BASE",)),
+                (
+                    "607100",
+                    "non_deductible_product_total",
+                    50.0,
+                    0.0,
+                    ("24_2 - TAX BASE",),
+                ),
+                # Non-deductible VAT reversal: 50% of 21 = 10.5.
+                ("442600", "non_deductible_tax_ro", -10.5, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 10.5, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(len(account_move.line_ids), 6)
+        self.assertEqual(self._aml_signature(account_move), expected)
+        # No deductible VAT line and no automatic balancing line.
+        self.assertFalse(
+            account_move.line_ids.filtered(lambda line: line.display_type == "tax")
+        )
+        self.assertEqual(
+            sum(account_move.line_ids.mapped("debit")),
+            sum(account_move.line_ids.mapped("credit")),
+        )
+
+    def test_consum_100_percent(self):
+        """A fully non-deductible consumption reverses the whole base and VAT."""
+        account_move = self._consume("100")
+
+        expected = sorted(
+            [
+                ("371000", "product", 0.0, 100.0, ()),
+                ("607000", "product", 100.0, 0.0, ()),
+                ("607000", "non_deductible_product", -100.0, 0.0, ("24 - TAX BASE",)),
+                (
+                    "607100",
+                    "non_deductible_product_total",
+                    100.0,
+                    0.0,
+                    ("24_2 - TAX BASE",),
+                ),
+                ("442600", "non_deductible_tax_ro", -21.0, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 21.0, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(len(account_move.line_ids), 6)
+        self.assertEqual(self._aml_signature(account_move), expected)
+        self.assertFalse(
+            account_move.line_ids.filtered(lambda line: line.display_type == "tax")
+        )
+        self.assertEqual(
+            sum(account_move.line_ids.mapped("debit")),
+            sum(account_move.line_ids.mapped("credit")),
+        )

--- a/l10n_ro_nondeductible_vat/tests/test_inventory.py
+++ b/l10n_ro_nondeductible_vat/tests/test_inventory.py
@@ -12,9 +12,107 @@ _logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
-class TestNonDeductibleInvoice(TestNondeductibleCommon):
+class TestNonDeductibleInventory(TestNondeductibleCommon):
     @TestNondeductibleCommon.setup_country("ro")
     def setUp(cls):
         super().setUp()
 
-    # Test minus inventar nedeductibil
+    def _inventory_minus(self, percent="50", counted=9):
+        """Remove `10 - counted` unit(s) (each valued 100) through an inventory
+        adjustment with the given non-deductibility, mirroring what the user
+        does in the on-hand list: edit the existing quant, set the counted
+        quantity and the non-deductible tax, then apply. Returns the generated
+        valuation account move."""
+        quant = self.env["stock.quant"]._gather(self.product_fifo, self.location)
+        quant = quant.with_context(inventory_mode=True)
+        quant.write(
+            {
+                "l10n_ro_nondeductible_tax_id": self.tax.id,
+                "l10n_ro_nondeductible_percent": percent,
+                "inventory_quantity": counted,
+            }
+        )
+        existing = self.env["stock.move"].search(
+            [("product_id", "=", self.product_fifo.id)]
+        )
+        quant.action_apply_inventory()
+        move = self.env["stock.move"].search(
+            [("product_id", "=", self.product_fifo.id), ("id", "not in", existing.ids)],
+            order="id desc",
+            limit=1,
+        )
+        return move.account_move_id
+
+    def _aml_signature(self, account_move):
+        return sorted(
+            (
+                line.account_id.code,
+                line.display_type,
+                line.debit,
+                line.credit,
+                tuple(sorted(line.tax_tag_ids.mapped("name"))),
+            )
+            for line in account_move.line_ids
+        )
+
+    def test_inventory_minus_50_percent(self):
+        """A 50% non-deductible inventory loss of goods valued 100 behaves like
+        a consumption: no deductible VAT line, only the non-deductible base and
+        VAT reversal."""
+        account_move = self._inventory_minus("50")
+
+        expected = sorted(
+            [
+                ("371000", "product", 0.0, 100.0, ()),
+                ("607000", "product", 100.0, 0.0, ()),
+                ("607000", "non_deductible_product", -50.0, 0.0, ("24 - TAX BASE",)),
+                (
+                    "607100",
+                    "non_deductible_product_total",
+                    50.0,
+                    0.0,
+                    ("24_2 - TAX BASE",),
+                ),
+                ("442600", "non_deductible_tax_ro", -10.5, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 10.5, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(len(account_move.line_ids), 6)
+        self.assertEqual(self._aml_signature(account_move), expected)
+        self.assertFalse(
+            account_move.line_ids.filtered(lambda line: line.display_type == "tax")
+        )
+        self.assertEqual(
+            sum(account_move.line_ids.mapped("debit")),
+            sum(account_move.line_ids.mapped("credit")),
+        )
+
+    def test_inventory_minus_100_percent(self):
+        """A fully non-deductible inventory loss reverses the whole base/VAT."""
+        account_move = self._inventory_minus("100")
+
+        expected = sorted(
+            [
+                ("371000", "product", 0.0, 100.0, ()),
+                ("607000", "product", 100.0, 0.0, ()),
+                ("607000", "non_deductible_product", -100.0, 0.0, ("24 - TAX BASE",)),
+                (
+                    "607100",
+                    "non_deductible_product_total",
+                    100.0,
+                    0.0,
+                    ("24_2 - TAX BASE",),
+                ),
+                ("442600", "non_deductible_tax_ro", -21.0, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 21.0, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(len(account_move.line_ids), 6)
+        self.assertEqual(self._aml_signature(account_move), expected)
+        self.assertFalse(
+            account_move.line_ids.filtered(lambda line: line.display_type == "tax")
+        )
+        self.assertEqual(
+            sum(account_move.line_ids.mapped("debit")),
+            sum(account_move.line_ids.mapped("credit")),
+        )

--- a/l10n_ro_nondeductible_vat/tests/test_vatp.py
+++ b/l10n_ro_nondeductible_vat/tests/test_vatp.py
@@ -1,0 +1,268 @@
+# Copyright (C) 2021 NextERP Romania
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import Command, fields
+from odoo.tests import tagged
+
+from .common import TestNondeductibleCommon
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install")
+class TestNonDeductibleVATP(TestNondeductibleCommon):
+    @TestNondeductibleCommon.setup_country("ro")
+    def setUp(cls):
+        super().setUp()
+
+    def _aml_signature(self, move):
+        return sorted(
+            (
+                line.account_id.code,
+                line.display_type,
+                line.debit,
+                line.credit,
+                tuple(sorted(line.tax_tag_ids.mapped("name"))),
+            )
+            for line in move.line_ids
+        )
+
+    def _post_and_pay(self, percent):
+        inv = self.vatp_nd_invoice
+        inv.invoice_line_ids.deductible_amount = 100 - int(percent)
+        inv.action_post()
+        invoice_sig = self._aml_signature(inv)
+        self.env["account.payment.register"].with_context(
+            active_model="account.move", active_ids=inv.ids
+        ).create({"payment_date": fields.Date.today()})._create_payments()
+        cb_move = inv.tax_cash_basis_created_move_ids
+        return inv, invoice_sig, cb_move
+
+    def test_vatp_invoice_defers_non_deductibility(self):
+        """On a VAT-on-payment bill the non-deductibility must NOT be split on
+        the invoice (deferred to payment): the bill only books the deferred VAT
+        on the transition account and the full payable."""
+        inv, invoice_sig, _cb = self._post_and_pay("50")
+
+        expected = sorted(
+            [
+                ("607000", "product", 100.0, 0.0, ()),
+                ("442820", "tax", 21.0, 0.0, ()),
+                ("401100", "payment_term", 0.0, 121.0, ()),
+            ]
+        )
+        self.assertEqual(invoice_sig, expected)
+        # No non-deductible line whatsoever on the invoice.
+        self.assertFalse(
+            inv.line_ids.filtered(
+                lambda line: line.display_type
+                in (
+                    "non_deductible_product",
+                    "non_deductible_product_total",
+                    "non_deductible_tax",
+                    "non_deductible_tax_ro",
+                )
+            )
+        )
+
+    def test_vatp_cash_basis_50_percent(self):
+        """At payment, the cash-basis entry splits the materialized VAT into a
+        deductible part (442600, 24 - VAT) and a non-deductible part booked as
+        expense (635200, 24_2 - VAT), and likewise splits the base grids."""
+        _inv, _sig, cb_move = self._post_and_pay("50")
+
+        expected = sorted(
+            [
+                ("442830", "product", 0.0, 100.0, ()),
+                ("442830", "product", 50.0, 0.0, ("24 - TAX BASE",)),
+                ("442830", "product", 50.0, 0.0, ("24_2 - TAX BASE",)),
+                ("442820", "tax", 0.0, 21.0, ()),
+                ("442600", "tax", 10.5, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 10.5, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(len(cb_move.line_ids), 6)
+        self.assertEqual(self._aml_signature(cb_move), expected)
+        self.assertEqual(
+            sum(cb_move.line_ids.mapped("debit")),
+            sum(cb_move.line_ids.mapped("credit")),
+        )
+
+    def test_vatp_cash_basis_100_percent(self):
+        """Fully non-deductible: the whole materialized VAT becomes expense."""
+        _inv, _sig, cb_move = self._post_and_pay("100")
+
+        expected = sorted(
+            [
+                ("442830", "product", 0.0, 100.0, ()),
+                ("442830", "product", 100.0, 0.0, ("24_2 - TAX BASE",)),
+                ("442820", "tax", 0.0, 21.0, ()),
+                ("635200", "non_deductible_tax_ro", 21.0, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(self._aml_signature(cb_move), expected)
+        self.assertFalse(
+            cb_move.line_ids.filtered(lambda line: line.account_id.code == "442600")
+        )
+        self.assertEqual(
+            sum(cb_move.line_ids.mapped("debit")),
+            sum(cb_move.line_ids.mapped("credit")),
+        )
+
+    def _create_vatp_bill(self, lines):
+        return self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.lxt_partner.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": name,
+                            "product_id": self.product_fifo.id,
+                            "account_id": self.account_expense.id,
+                            "quantity": 1,
+                            "price_unit": price,
+                            "deductible_amount": deductible,
+                            "tax_ids": [Command.set(self.vatp_tax.ids)],
+                        }
+                    )
+                    for name, price, deductible in lines
+                ],
+            }
+        )
+
+    def test_vatp_multiline_partial_payment(self):
+        """Two product lines (100 + 200, both 50% non-deductible) paid half:
+        the cash-basis split must be proportional to the paid amount."""
+        inv = self._create_vatp_bill([("L1", 100.0, 50), ("L2", 200.0, 50)])
+        inv.action_post()
+        # 300 base + 63 VAT, deferred, full payable.
+        self.assertEqual(
+            sorted(inv.line_ids.mapped("balance")), [-363.0, 63.0, 100.0, 200.0]
+        )
+
+        self.env["account.payment.register"].with_context(
+            active_model="account.move", active_ids=inv.ids
+        ).create(
+            {"payment_date": fields.Date.today(), "amount": 181.5}
+        )._create_payments()
+
+        cb_move = inv.tax_cash_basis_created_move_ids
+        expected = sorted(
+            [
+                ("442830", "product", 0.0, 150.0, ()),
+                ("442830", "product", 75.0, 0.0, ("24 - TAX BASE",)),
+                ("442830", "product", 75.0, 0.0, ("24_2 - TAX BASE",)),
+                ("442820", "tax", 0.0, 31.5, ()),
+                ("442600", "tax", 15.75, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 15.75, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(self._aml_signature(cb_move), expected)
+        self.assertEqual(
+            sum(cb_move.line_ids.mapped("debit")),
+            sum(cb_move.line_ids.mapped("credit")),
+        )
+
+    def test_vatp_mixed_deductibility_same_tax(self):
+        """Two lines on the same on-payment tax with different deductibility
+        (100 @ 50% non-deductible, 200 fully deductible): the cash-basis split
+        is weighted by base, so only 50 of base / 10.5 of VAT is non-deductible."""
+        inv = self._create_vatp_bill([("L1", 100.0, 50), ("L2", 200.0, 100)])
+        inv.action_post()
+
+        self.env["account.payment.register"].with_context(
+            active_model="account.move", active_ids=inv.ids
+        ).create({"payment_date": fields.Date.today()})._create_payments()
+
+        cb_move = inv.tax_cash_basis_created_move_ids
+        expected = sorted(
+            [
+                ("442830", "product", 0.0, 300.0, ()),
+                ("442830", "product", 250.0, 0.0, ("24 - TAX BASE",)),
+                ("442830", "product", 50.0, 0.0, ("24_2 - TAX BASE",)),
+                ("442820", "tax", 0.0, 63.0, ()),
+                ("442600", "tax", 52.5, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 10.5, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(self._aml_signature(cb_move), expected)
+        self.assertEqual(
+            sum(cb_move.line_ids.mapped("debit")),
+            sum(cb_move.line_ids.mapped("credit")),
+        )
+
+    def test_vatp_deductible_and_nondeductible_same_tax_grids(self):
+        """A deductible and a non-deductible VAT-on-payment tax sharing the
+        very same grids (24 - VAT) coexist on one bill. At payment, only the
+        non-deductible tax is split; the deductible one keeps its full VAT on
+        442600 (24 - VAT) without any bleeding."""
+        inv = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.lxt_partner.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Ded",
+                            "product_id": self.product_fifo.id,
+                            "account_id": self.account_expense.id,
+                            "quantity": 1,
+                            "price_unit": 200.0,
+                            "deductible_amount": 100,
+                            "tax_ids": [Command.set(self.vatp_tax_deductible.ids)],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "name": "NonDed",
+                            "product_id": self.product_fifo.id,
+                            "account_id": self.account_expense.id,
+                            "quantity": 1,
+                            "price_unit": 100.0,
+                            "deductible_amount": 50,
+                            "tax_ids": [Command.set(self.vatp_tax.ids)],
+                        }
+                    ),
+                ],
+            }
+        )
+        inv.action_post()
+        # Deferred, full payable, no split on the invoice.
+        self.assertEqual(inv.amount_total, 363.0)
+        self.assertFalse(
+            inv.line_ids.filtered(
+                lambda line: "non_deductible" in (line.display_type or "")
+            )
+        )
+
+        self.env["account.payment.register"].with_context(
+            active_model="account.move", active_ids=inv.ids
+        ).create({"payment_date": fields.Date.today()})._create_payments()
+
+        cb_move = inv.tax_cash_basis_created_move_ids
+        expected = sorted(
+            [
+                # Deductible tax (200 base / 42 VAT) - kept whole.
+                ("442830", "product", 0.0, 200.0, ()),
+                ("442830", "product", 200.0, 0.0, ("24 - TAX BASE",)),
+                ("442820", "tax", 0.0, 42.0, ()),
+                ("442600", "tax", 42.0, 0.0, ("24 - VAT",)),
+                # Non-deductible tax (100 base / 21 VAT, 50%) - split.
+                ("442830", "product", 0.0, 100.0, ()),
+                ("442830", "product", 50.0, 0.0, ("24 - TAX BASE",)),
+                ("442830", "product", 50.0, 0.0, ("24_2 - TAX BASE",)),
+                ("442820", "tax", 0.0, 21.0, ()),
+                ("442600", "tax", 10.5, 0.0, ("24 - VAT",)),
+                ("635200", "non_deductible_tax_ro", 10.5, 0.0, ("24_2 - VAT",)),
+            ]
+        )
+        self.assertEqual(self._aml_signature(cb_move), expected)
+        self.assertEqual(
+            sum(cb_move.line_ids.mapped("debit")),
+            sum(cb_move.line_ids.mapped("credit")),
+        )


### PR DESCRIPTION
…ment

Stock (consumption and minus inventory): the VAT was already deducted on reception, so the stock valuation entry must not generate a fresh deductible VAT line (nor an automatic balancing line). Apply the l10n_ro_exclude_from_stock context on the valuation move when the stock move carries a non-deductible tax, so only the non-deductible reversal is kept.

VAT on payment (cash basis): non-deductibility is realized only when the invoice is paid. The split is therefore deferred on the invoice (which keeps the full, correct payable) and materialized on the cash-basis entry generated at payment, moving the non-deductible part of the VAT to the expense account and splitting the base/VAT grids. The non-deductible fraction is weighted by base, so several lines on the same tax with different deductibilities, partial payments, and a deductible tax coexisting with a non-deductible one are all handled correctly.

Add dedicated non-deductible taxes in the test common (regular + VAT on payment) and tests for consumption, minus inventory and the VAT on payment flows.