### PR TITLE
[19.0][FIX] l10n_ro_pos: prevent stock keys crashing POS session closing

### DIFF
--- a/l10n_ro_pos/models/pos_session.py
+++ b/l10n_ro_pos/models/pos_session.py
@@ -18,14 +18,16 @@ class PosSession(models.Model):
     def _accumulate_amounts(self, data):
         data = super()._accumulate_amounts(data)
         if self.company_id.l10n_ro_accounting:
-            amounts = {"amount": 0.0, "amount_converted": 0.0}
             # nu trebuie generate note contabile
-            # pentru ca acestea sunt generate in miscarea de stoc
+            # pentru ca acestea sunt generate in miscarea de stoc.
+            # In Odoo 19 cheile sunt dict-uri grupate pe cont (defaultdict),
+            # consumate cu .items() => fiecare valoare trebuie sa fie un dict
+            # {amount, amount_converted}. Le golim ca sa nu se genereze linii.
             data.update(
                 {
-                    "stock_expense": amounts,
-                    "stock_return": amounts,
-                    "stock_output": amounts,
+                    "stock_expense": {},
+                    "stock_return": {},
+                    "stock_output": {},
                 }
             )
         return data

--- a/l10n_ro_pos/tests/test_pos.py
+++ b/l10n_ro_pos/tests/test_pos.py
@@ -174,19 +174,16 @@ class TestReportPoSOrder(CommonPosTest):
             data,
             "Trebuie să existe cheile pentru stoc în datele acumulate",
         )
-        # All amounts related to stock should be 0.0 since no accounting entries
-        # are generated for stock in l10n_ro_accounting:
-        # amounts = {"amount": 0.0, "amount_converted": 0.0}
+        # Cheile de stoc trebuie să fie dict-uri goale, deoarece nu se generează
+        # note contabile pentru stoc în l10n_ro_accounting (sunt generate în
+        # mișcarea de stoc). În Odoo 19 aceste structuri sunt grupate pe cont și
+        # consumate cu .items() la închiderea sesiunii — fiecare valoare ar fi
+        # trebuit să fie un dict {amount, amount_converted}, deci golirea lor
+        # previne generarea liniilor (și TypeError-ul de la iterare).
         for key in ["stock_expense", "stock_return", "stock_output"]:
             self.assertEqual(
-                data[key]["amount"],
-                0.0,
-                f"Suma pentru {key} ar trebui să fie 0.0 deoarece nu se generează \
+                data[key],
+                {},
+                f"Cheia {key} ar trebui să fie goală deoarece nu se generează \
                 note contabile pentru stoc",
-            )
-            self.assertEqual(
-                data[key]["amount_converted"],
-                0.0,
-                f"Suma convertită pentru {key} ar trebui să fie 0.0 deoarece nu se \
-                generează note contabile pentru stoc",
             )


### PR DESCRIPTION
## Problem

Closing/validating a POS session on a company with `l10n_ro_accounting` enabled crashes with:

```
File ".../point_of_sale/models/pos_session.py", line 1044, in _create_non_reconciliable_move_lines
    [self._get_stock_expense_vals(key, amounts['amount'], amounts['amount_converted']) for key, amounts in stock_expense.items()]
TypeError: 'float' object is not subscriptable
```

## Cause

In Odoo 19, `stock_expense` / `stock_return` / `stock_valuation` are `defaultdict`s **grouped per account**, consumed with `.items()` — so each value must be a dict `{'amount', 'amount_converted'}`.

`l10n_ro_pos` overrode them in `_accumulate_amounts` with a single **flat** dict `{"amount": 0.0, "amount_converted": 0.0}`. Iterating that dict during session validation yields `("amount", 0.0)` / `("amount_converted", 0.0)`, i.e. plain floats, hence the `TypeError`. This worked under the 18.0 flat structure but broke on 19.0.

## Fix

Under `l10n_ro_accounting` no accounting entries should be generated for stock (they are posted in the stock moves). Setting these keys to **empty dicts** keeps that intent while making `.items()` yield nothing, so no move lines are created and no iteration fails.

The existing test asserted the broken shape (`data[key]["amount"] == 0.0`) and never exercised session closing, so it passed while production crashed; it now asserts the keys are empty dicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)