### PR TITLE
[FIX] l10n_ro_pos: empty stock_valuation to avoid unbalanced closing …

### DIFF
--- a/l10n_ro_pos/__manifest__.py
+++ b/l10n_ro_pos/__manifest__.py
@@ -3,7 +3,7 @@
 # See README.rst file on addons root folder for license details
 {
     "name": "Romania - Point of Sale",
-    "version": "19.0.1.6.0",
+    "version": "19.0.1.6.1",
     "category": "Localization",
     "countries": ["ro"],
     "license": "AGPL-3",

--- a/l10n_ro_pos/models/pos_session.py
+++ b/l10n_ro_pos/models/pos_session.py
@@ -23,11 +23,19 @@ class PosSession(models.Model):
             # In Odoo 19 cheile sunt dict-uri grupate pe cont (defaultdict),
             # consumate cu .items() => fiecare valoare trebuie sa fie un dict
             # {amount, amount_converted}. Le golim ca sa nu se genereze linii.
+            #
+            # IMPORTANT: trebuie golit si "stock_valuation". Core-ul O19 il
+            # consuma separat in _create_stock_valuation_lines (apelat din
+            # _create_account_move), iar contrapartida sa (stock_output) e deja
+            # golita aici. Daca lasam "stock_valuation" populat, se genereaza o
+            # linie de valorizare fara contrapartida => nota de inchidere iese
+            # dezechilibrata exact cu costul marfii al comenzilor nefacturate.
             data.update(
                 {
                     "stock_expense": {},
                     "stock_return": {},
                     "stock_output": {},
+                    "stock_valuation": {},
                 }
             )
         return data

--- a/l10n_ro_pos/tests/test_pos.py
+++ b/l10n_ro_pos/tests/test_pos.py
@@ -174,13 +174,23 @@ class TestReportPoSOrder(CommonPosTest):
             data,
             "Trebuie să existe cheile pentru stoc în datele acumulate",
         )
+        self.assertIn(
+            "stock_valuation",
+            data,
+            "Trebuie să existe cheile pentru stoc în datele acumulate",
+        )
         # Cheile de stoc trebuie să fie dict-uri goale, deoarece nu se generează
         # note contabile pentru stoc în l10n_ro_accounting (sunt generate în
         # mișcarea de stoc). În Odoo 19 aceste structuri sunt grupate pe cont și
         # consumate cu .items() la închiderea sesiunii — fiecare valoare ar fi
         # trebuit să fie un dict {amount, amount_converted}, deci golirea lor
         # previne generarea liniilor (și TypeError-ul de la iterare).
-        for key in ["stock_expense", "stock_return", "stock_output"]:
+        #
+        # "stock_valuation" trebuie golit explicit: e consumat separat de core în
+        # _create_stock_valuation_lines, iar dacă rămâne populat generează o linie
+        # de valorizare fără contrapartidă (stock_output e golit) => notă de
+        # închidere dezechilibrată cu costul mărfii comenzilor nefacturate.
+        for key in ["stock_expense", "stock_return", "stock_output", "stock_valuation"]:
             self.assertEqual(
                 data[key],
                 {},


### PR DESCRIPTION
…move

When l10n_ro_accounting is enabled, stock accounting entries are posted by the stock moves (real-time valuation), so the POS session closing move must not generate any stock line. The override already empties stock_expense, stock_return and stock_output, but NOT stock_valuation.

In Odoo 19 core, stock_valuation is consumed separately by _create_stock_valuation_lines (called from _create_account_move). Leaving it populated creates a one-sided valuation line whose counterpart (stock_output) has been emptied here, so the closing move ends up unbalanced by exactly the cost of goods of the non-invoiced orders, forcing a "close session forced" dialog (e.g. -10,103.79).

Empty stock_valuation as well so the closing move balances to zero.

Verified on production data (valshop): imbalance -10,103.79 -> 0.00.