### PR TITLE
[18.0][FIX] l10n_ro_stock_account: avoid bool/str sort error in _compute_account

### DIFF
--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "18.0.1.25.0",
+    "version": "18.0.1.25.1",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -91,9 +91,9 @@ class StockValuationLayer(models.Model):
                 not svl.l10n_ro_valued_type or "internal" not in svl.l10n_ro_valued_type
             ):
                 for aml in svl.account_move_id.line_ids.sorted(
-                    lambda layer: layer.account_id.code
+                    lambda layer: layer.account_id.code or ""
                 ):
-                    if aml.account_id.code[0] in ["2", "3"]:
+                    if aml.account_id.code and aml.account_id.code[0] in ["2", "3"]:
                         if round(aml.balance, 2) == round(svl.value, 2):
                             account = aml.account_id
                             break

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,0 +1,8 @@
+## 18.0.1.25.1
+
+- Fix `TypeError: '<' not supported between instances of 'bool' and 'str'` in
+  `stock_valuation_layer._compute_account` when sorting the account move lines.
+  A journal item without an account (or whose account has no code) returns
+  `False` for `account_id.code`, which cannot be compared against the string
+  codes of the other lines. The sort key now falls back to an empty string, and
+  the subsequent `code[0]` check guards against an empty/falsy code.


### PR DESCRIPTION
## Problem

In production, computing fields on `account.move` raised:

```
File ".../l10n_ro_stock_account/models/stock_valuation_layer.py", line 93, in _compute_account
    for aml in svl.account_move_id.line_ids.sorted(
File ".../odoo/models.py", in sorted
    ids = tuple(item.id for item in sorted(self, key=key, reverse=reverse))
TypeError: '<' not supported between instances of 'bool' and 'str'
```

`_compute_account` sorts the journal items by `account_id.code`. When a line has no account (or the account has no code), `account_id.code` returns `False` (bool), which Python cannot compare against the string codes of the other lines.

## Fix

- Sort key falls back to an empty string: `lambda layer: layer.account_id.code or ""`.
- Guard the subsequent `code[0]` check against an empty/falsy code, avoiding a follow-up `IndexError`/`TypeError`.

No functional change for moves whose lines all have account codes.