### PR TITLE
[19.0][FIX] l10n_ro_stock_account: avoid bool/str sort error in _compute_account

### DIFF
--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.0.19.0",
+    "version": "19.0.0.19.1",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -100,9 +100,9 @@ class StockMove(models.Model):
             if move.account_move_id and "internal" not in move.l10n_ro_move_type:
                 for account_move in move.account_move_id:
                     for aml in account_move.line_ids.sorted(
-                        lambda line: line.account_id.code
+                        lambda line: line.account_id.code or ""
                     ):
-                        if aml.account_id.code[0] in ["2", "3"]:
+                        if aml.account_id.code and aml.account_id.code[0] in ["2", "3"]:
                             if round(aml.balance, 2) == round(move.value, 2):
                                 account = aml.account_id
                                 break

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,0 +1,8 @@
+## 19.0.0.19.1
+
+- Fix `TypeError: '<' not supported between instances of 'bool' and 'str'` in
+  `stock_move._compute_account` when sorting the account move lines. A journal item
+  without an account (or whose account has no code) returns `False` for
+  `account_id.code`, which cannot be compared against the string codes of the
+  other lines. The sort key now falls back to an empty string, and the
+  subsequent `code[0]` check guards against an empty/falsy code.


### PR DESCRIPTION
## Problem

In production (18.0, agroamat) computing the stock valuation account raised:

```
TypeError: '<' not supported between instances of 'bool' and 'str'
```

`_compute_account` sorts the journal items by `account_id.code`. When a line has no account (or the account has no code), `account_id.code` returns `False` (bool), which Python cannot compare against the string codes of the other lines. On 19.0 the same pattern lives in `stock_move._compute_account`.

## Fix

- Sort key falls back to an empty string: `lambda line: line.account_id.code or ""`.
- Guard the subsequent `code[0]` check against an empty/falsy code, avoiding a follow-up `IndexError`/`TypeError`.

Forward-port of the 18.0 fix (OCA/l10n-romania#1511).