### PR TITLE
[18.0][FIX] l10n_ro_stock_account: correct valuation account on zero-value moves

### DIFF
--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "18.0.1.26.0",
+    "version": "18.0.1.26.1",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/migrations/18.0.1.26.1/post-migration.py
+++ b/l10n_ro_stock_account/migrations/18.0.1.26.1/post-migration.py
@@ -1,0 +1,33 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Re-attribute the valuation account on zero-value layers.
+
+    Before this version ``_compute_account`` picked the source/destination
+    valuation account based on the *value* sign. Zero-value moves (e.g. a
+    100% discounted / free product) have value == 0 on every layer, so both
+    the out-leg and the in-leg ended up on the category default account,
+    leaving residual quantities on the per-account stock card. The compute
+    now keys on the *quantity* sign, so we recompute the stored
+    ``l10n_ro_account_id`` for the historical zero-value layers to fix the
+    stock card retroactively.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    layers = env["stock.valuation.layer"].search([("value", "=", 0)])
+    layers = layers.filtered(lambda sv: sv.stock_move_id.is_l10n_ro_record)
+    if not layers:
+        return
+    _logger.info(
+        "l10n_ro_stock_account: recomputing l10n_ro_account_id "
+        "for %s zero-value layers",
+        len(layers),
+    )
+    layers.invalidate_recordset(["l10n_ro_account_id"])
+    layers._compute_account()
+    layers.flush_recordset(["l10n_ro_account_id"])

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -77,13 +77,20 @@ class StockValuationLayer(models.Model):
                 or svl.product_id.categ_id.property_stock_valuation_account_id
             )
             if svl.product_id.categ_id.l10n_ro_stock_account_change:
+                # Pick the source/destination valuation account based on the
+                # quantity sign, not the value sign. A zero-value move (e.g. a
+                # 100% discounted / free product) has value == 0 on every layer,
+                # so keying on ``value`` leaves both the out-leg and the in-leg
+                # on the category default account, breaking the per-account stock
+                # card (residual quantity on both warehouses). The quantity sign
+                # always reflects the leg direction, including for value == 0.
                 if (
-                    svl.value > 0
+                    svl.quantity > 0
                     and loc_dest.l10n_ro_property_stock_valuation_account_id
                 ):
                     account = loc_dest.l10n_ro_property_stock_valuation_account_id
                 if (
-                    svl.value < 0
+                    svl.quantity < 0
                     and loc_scr.l10n_ro_property_stock_valuation_account_id
                 ):
                     account = loc_scr.l10n_ro_property_stock_valuation_account_id


### PR DESCRIPTION
## Problem

For an internal transfer of a **zero-value** product (e.g. a 100% discounted or free product), the **per-account stock sheet** (fișă de magazie pe gestiuni) keeps residual quantities: `+1 / 0` on the source warehouse account and `-1 / 0` on the destination account, even though the net quantity is zero.

Reported from production (Romanian customer, Odoo 18): a SIM card bought with a 100% discount (final value 0), transferred internally from `Mărfuri (371011)` to `Alte materiale consumabile (302800)` and consumed — both accounts stay at `±1 / 0` at month end instead of closing to zero.

## Cause

In `l10n_ro_stock_account/models/stock_valuation_layer.py`, `_compute_account` selects the source/destination valuation account based on the **value** sign:

```python
if svl.value > 0 and loc_dest...: account = loc_dest...   # destination
if svl.value < 0 and loc_scr...:  account = loc_scr...    # source
```

When the move value is 0 neither branch is taken, so both the out-leg and the in-leg fall back to the category default account → the source warehouse is never discharged on the stock card.

## Fix

Key the selection on the **quantity** sign (`svl.quantity`), which always reflects the leg direction, including for `value == 0`. For non-zero values the behaviour is unchanged since the value and quantity signs match.

A **post-migration** (`18.0.1.26.1`) recomputes the stored `l10n_ro_account_id` for historical zero-value layers, so the stock sheet is corrected retroactively on update.

## Test

Verified on a production copy: before the fix the transfer out-leg was attributed to the destination account; after fix + post-migration both accounts close at `0 / 0` at month end, and the recompute covers all zero-value layers, not only the reported product.

@dhongu @feketemihai

🤖 Generated with [Claude Code](https://claude.com/claude-code)