### PR TITLE
[FIX] use official OCA maintainer-tools for pre-commit (bug tracker rebranded to nexterp.ro)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,8 @@ repos:
     rev: v1.3
     hooks:
       - id: whool-init
-  - repo: https://github.com/NextERP-Romania/maintainer-tools
-    rev: d0d5862c4b5354776193c260dbd3a9442e3ce3a4
+  - repo: https://github.com/oca/maintainer-tools
+    rev: f9b919b9868143135a9c9cb03021089cabba8223
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons


### PR DESCRIPTION
## Problem

The `19.0` branch pulls the maintainer-tools hooks (`oca-gen-addon-readme`, `oca-fix-manifest-website`, ...) from a **fork**:

```yaml
- repo: https://github.com/NextERP-Romania/maintainer-tools
  rev: d0d5862c4b5354776193c260dbd3a9442e3ce3a4
```

That fork's README template rewrites every addon's **Bug Tracker** section to `https://www.nexterp.ro/helpdesk` instead of the repository's GitHub Issues. As a result, **any** commit that regenerates a `README.rst` on this branch silently rebrands the bug tracker (and the "feedback" link) to a third-party helpdesk — even when the hook args correctly say `--org-name=OCA --repo-name=l10n-romania`.

## Fix

Point the hook at the official `https://github.com/oca/maintainer-tools` at the rev used across OCA 19.0 repos (`f9b919b`, same as OCA/server-tools, OCA/web, OCA/account-financial-tools). Regenerated READMEs then correctly link to `https://github.com/OCA/l10n-romania/issues`.

Config-only change; pre-commit.ci will regenerate the affected READMEs.