### PR TITLE
[19.0][FIX] l10n_ro_stock_account: drop stale stock.picking.type fiscal position view

### DIFF
--- a/l10n_ro_message_spv/i18n/ro.po
+++ b/l10n_ro_message_spv/i18n/ro.po
@@ -141,6 +141,11 @@ msgid "Download"
 msgstr "Descarcă"
 
 #. module: l10n_ro_message_spv
+#: model:ir.model.fields,field_description:l10n_ro_message_spv.field_l10n_ro_message_spv__download_attempts
+msgid "Download Attempts"
+msgstr ""
+
+#. module: l10n_ro_message_spv
 #: model:ir.model.fields.selection,name:l10n_ro_message_spv.selection__l10n_ro_message_spv__state__downloaded
 msgid "Downloaded"
 msgstr "Descărcat"
@@ -265,6 +270,11 @@ msgstr ""
 #: model:ir.model,name:l10n_ro_message_spv.model_account_move_line
 msgid "Journal Item"
 msgstr "Element jurnal"
+
+#. module: l10n_ro_message_spv
+#: model:ir.model.fields,field_description:l10n_ro_message_spv.field_l10n_ro_message_spv__last_download_date
+msgid "Last Download Date"
+msgstr ""
 
 #. module: l10n_ro_message_spv
 #: model:ir.model.fields,field_description:l10n_ro_message_spv.field_l10n_ro_message_spv__write_uid

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.0.20.0",
+    "version": "19.0.0.21.0",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/migrations/19.0.0.21.0/pre-migration.py
+++ b/l10n_ro_stock_account/migrations/19.0.0.21.0/pre-migration.py
@@ -1,0 +1,36 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # In 19.0 the l10n_ro_fiscal_position_id field moved from stock.picking.type
+    # to stock.warehouse. On databases migrated from 18.0 the old view and column
+    # remain and break the validation of any view that inherits the
+    # stock.picking.type form. Clean them up before the data is loaded.
+    cr.execute(
+        """
+        DELETE FROM ir_ui_view
+         WHERE id IN (
+            SELECT res_id FROM ir_model_data
+             WHERE module = 'l10n_ro_stock_account'
+               AND name = 'view_picking_type_form'
+               AND model = 'ir.ui.view'
+         )
+        """
+    )
+    cr.execute(
+        """
+        DELETE FROM ir_model_data
+         WHERE module = 'l10n_ro_stock_account'
+           AND name = 'view_picking_type_form'
+        """
+    )
+    cr.execute(
+        "ALTER TABLE stock_picking_type "
+        "DROP COLUMN IF EXISTS l10n_ro_fiscal_position_id"
+    )
+    _logger.info(
+        "l10n_ro_stock_account: removed stale stock.picking.type "
+        "l10n_ro_fiscal_position_id view and column"
+    )


### PR DESCRIPTION
## Problem

In 18.0 `l10n_ro_stock_account` defined `l10n_ro_fiscal_position_id` on **`stock.picking.type`** together with the `view_picking_type_form` view (xpath after `warehouse_id`).

In 19.0 the field was **moved to `stock.warehouse`** and both the `StockPickingType` model class and the `view_picking_type_form` view were removed from the code.

On databases upgraded from 18.0, the obsolete `ir.ui.view` record and the orphan `l10n_ro_fiscal_position_id` column survive the upgrade. When any other module reloads a view inheriting the `stock.picking.type` form (e.g. `stock_barcode`'s picking type form override), Odoo revalidates the whole combined arch, hits the removed field and aborts the registry load with:

```
Field "l10n_ro_fiscal_position_id" does not exist in model "stock.picking.type"
```

## Fix

A pre-migration (`19.0.0.21.0`) that, before the data is loaded:
- deletes the stale `l10n_ro_stock_account.view_picking_type_form` view record (and its `ir.model.data`);
- drops the orphan `l10n_ro_fiscal_position_id` column from `stock_picking_type`.

Manifest version bumped `19.0.0.20.0` → `19.0.0.21.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)