### PR TITLE
[18.0][FIX][REGRESSION] l10n_ro_stock_account: scope account-balance match to the layer's own product

### DIFF
--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -105,8 +105,18 @@ class StockValuationLayer(models.Model):
                 # and silently falls back to the category's default account,
                 # leaving a stock-card residual on the correct account. Group
                 # class 2/3 lines by account and match on the aggregated balance.
+                #
+                # A single journal entry can cover SEVERAL products (e.g. one
+                # landed cost split across a whole shipment) — restrict the
+                # aggregation to this layer's own product first, otherwise
+                # unrelated products' lines on the same account get folded
+                # into the sum and the match fails, or worse, coincidentally
+                # matches the wrong total.
+                candidate_lines = svl.account_move_id.line_ids.filtered(
+                    lambda aml, product=svl.product_id: aml.product_id == product
+                )
                 by_account = {}
-                for aml in svl.account_move_id.line_ids:
+                for aml in candidate_lines:
                     if aml.account_id.code and aml.account_id.code[0] in ["2", "3"]:
                         by_account[aml.account_id] = (
                             by_account.get(aml.account_id, 0.0) + aml.balance

--- a/l10n_ro_stock_account/tests/test_account_determination.py
+++ b/l10n_ro_stock_account/tests/test_account_determination.py
@@ -155,8 +155,24 @@ class TestStockAccountDetermination(TestStockCommon):
                 "move_type": "entry",
                 "journal_id": journal.id,
                 "line_ids": [
-                    (0, 0, {"account_id": target_account.id, "credit": 60.0}),
-                    (0, 0, {"account_id": target_account.id, "credit": 40.0}),
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": target_account.id,
+                            "product_id": self.product_1.id,
+                            "credit": 60.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": target_account.id,
+                            "product_id": self.product_1.id,
+                            "credit": 40.0,
+                        },
+                    ),
                     (0, 0, {"account_id": self.account_expense.id, "debit": 100.0}),
                 ],
             }
@@ -174,3 +190,81 @@ class TestStockAccountDetermination(TestStockCommon):
             }
         )
         self.assertEqual(svl.l10n_ro_account_id, target_account)
+
+    def test_account_determination_multiline_multiproduct_same_account(self):
+        """A single journal entry can cover several products on the SAME
+        stock account (e.g. one landed cost split across a whole shipment).
+        ``_compute_account`` must restrict the per-account aggregation to
+        this layer's own product — otherwise another product's lines on the
+        same account get folded into the sum, the total no longer matches
+        either product's individual ``value``, and both silently fall back
+        to the category's default account.
+        """
+        self.create_po()
+        move_1 = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_1
+        )
+        move_2 = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_2
+        )
+
+        target_account = self.account_valuation.copy({"name": "371998"})
+        journal = self.env["account.journal"].search(
+            [("type", "=", "general"), ("company_id", "=", self.env.company.id)],
+            limit=1,
+        )
+        account_move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": target_account.id,
+                            "product_id": self.product_1.id,
+                            "credit": 100.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": target_account.id,
+                            "product_id": self.product_2.id,
+                            "credit": 25.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {"account_id": self.account_expense.id, "debit": 125.0},
+                    ),
+                ],
+            }
+        )
+        account_move.action_post()
+
+        svl_1 = self.env["stock.valuation.layer"].create(
+            {
+                "company_id": self.env.company.id,
+                "product_id": self.product_1.id,
+                "stock_move_id": move_1.id,
+                "quantity": 0.0,
+                "value": -100.0,
+                "account_move_id": account_move.id,
+            }
+        )
+        svl_2 = self.env["stock.valuation.layer"].create(
+            {
+                "company_id": self.env.company.id,
+                "product_id": self.product_2.id,
+                "stock_move_id": move_2.id,
+                "quantity": 0.0,
+                "value": -25.0,
+                "account_move_id": account_move.id,
+            }
+        )
+        self.assertEqual(svl_1.l10n_ro_account_id, target_account)
+        self.assertEqual(svl_2.l10n_ro_account_id, target_account)


### PR DESCRIPTION
## ⚠️ Regression follow-up to #1528

The fix merged in #1528 (aggregate a stock account's lines instead of matching a single line's balance) aggregated **all** class 2/3 lines on an account within the journal entry, without restricting to the valuation layer's own product. In real data, a single landed cost routinely covers a whole shipment (dozens of products) in one journal entry — lines for **other** products on the same account got folded into the sum, which then matched neither product's own value, and fell back to the category's default account. This includes layers that were **previously correctly attributed**, i.e. #1528 introduced a regression for multi-product landed costs.

## Verification
On production data (ticket 8136): 69 of 82 distinct landed-cost journal entries touch more than one product (up to 43 products in a single entry). Empirically confirmed the regression before writing the fix: a layer (product `1970248C2.023`, account `371.11`) that was correctly attributed was pushed to the wrong generic account when recomputed under #1528's code.

## Fix
Filter `svl.account_move_id.line_ids` to lines whose `product_id` matches `svl.product_id` before grouping by account and matching on the aggregated balance.

## Test plan
- [x] Added `test_account_determination_multiline_multiproduct_same_account`: two products share one journal entry on the same account; asserts each layer resolves to its OWN value, not the combined total.
- [x] Confirmed this new test **fails** against #1528's merged code and **passes** with this fix.
- [x] Updated `test_account_determination_multiline_same_account` to set `product_id` on its journal lines (matching real landed-cost postings) so it continues to exercise the single-product case correctly.
- [x] Full `l10n_ro_stock_account` suite: 32/32 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)