### PR TITLE
[IMP] l10n_ro_message_spv: friendly error and header buttons for downloads

### DIFF
--- a/l10n_ro_message_spv/README.rst
+++ b/l10n_ro_message_spv/README.rst
@@ -74,6 +74,18 @@ Configuration
 Changelog
 =========
 
+18.0.2.1.1 (2026-07-05)
+-----------------------
+
+- Clicking "Download embedded PDF" when the invoice XML has no embedded
+  PDF now raises a user-friendly error instead of navigating to a raw
+  404 page.
+- The form view no longer shows the derived attachment fields (ZIP, XML,
+  ANAF PDF, embedded PDF) with their file names, since those are only
+  materialized on demand and often have no name to display. The four
+  download actions are now buttons with suggestive icons in the form
+  header instead.
+
 18.0.2.0.0 (2026-07-02)
 -----------------------
 

--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "18.0.2.1.0",
+    "version": "18.0.2.1.1",
     "author": "Terrabit," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -679,9 +679,7 @@ class MessageSPV(models.Model):
             return self._action_download(self.attachment_embedded_pdf_id.id)
         _name, pdf_bytes = self._get_embedded_pdf_bytes()
         if not pdf_bytes:
-            raise UserError(
-                _("This invoice's XML does not contain an embedded PDF.")
-            )
+            raise UserError(_("This invoice's XML does not contain an embedded PDF."))
         return self._action_download_derived("embedded_pdf")
 
     def _action_download(self, attachment_field_id):

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -677,6 +677,11 @@ class MessageSPV(models.Model):
         self.ensure_one()
         if self.attachment_embedded_pdf_id:
             return self._action_download(self.attachment_embedded_pdf_id.id)
+        _name, pdf_bytes = self._get_embedded_pdf_bytes()
+        if not pdf_bytes:
+            raise UserError(
+                _("This invoice's XML does not contain an embedded PDF.")
+            )
         return self._action_download_derived("embedded_pdf")
 
     def _action_download(self, attachment_field_id):

--- a/l10n_ro_message_spv/readme/HISTORY.md
+++ b/l10n_ro_message_spv/readme/HISTORY.md
@@ -1,3 +1,14 @@
+## 18.0.2.1.1 (2026-07-05)
+
+- Clicking "Download embedded PDF" when the invoice XML has no embedded
+  PDF now raises a user-friendly error instead of navigating to a raw
+  404 page.
+- The form view no longer shows the derived attachment fields (ZIP, XML,
+  ANAF PDF, embedded PDF) with their file names, since those are only
+  materialized on demand and often have no name to display. The four
+  download actions are now buttons with suggestive icons in the form
+  header instead.
+
 ## 18.0.2.0.0 (2026-07-02)
 
 Storage optimization: the signed ANAF ZIP is now the only file stored per

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -310,10 +310,22 @@ class TestMessageSPV(TestMessageSPV):
         self.assertEqual(action["url"], f"/l10n_ro/message_spv/{message.id}/xml")
         action = message.action_download_anaf_pdf()
         self.assertEqual(action["url"], f"/l10n_ro/message_spv/{message.id}/anaf_pdf")
+
+    def test_action_download_embedded_pdf_url(self):
+        """When the XML holds an embedded PDF, the action points to the
+        on-the-fly controller route."""
+        message = self._create_message_with_zip("DL2", "TESTDL2", EMBEDDED_PDF_XML)
         action = message.action_download_embedded_pdf()
         self.assertEqual(
             action["url"], f"/l10n_ro/message_spv/{message.id}/embedded_pdf"
         )
+
+    def test_action_download_embedded_pdf_missing_raises(self):
+        """Clicking the button when the XML has no embedded PDF must raise
+        a user-friendly error instead of surfacing a raw 404."""
+        message = self._create_message_with_zip("DL3", "TESTDL3", b"<Invoice/>")
+        with self.assertRaises(UserError):
+            message.action_download_embedded_pdf()
 
     def test_unlink_account_move(self):
         """Testează funcționalitatea de ștergere a

--- a/l10n_ro_message_spv/views/message_spv_view.xml
+++ b/l10n_ro_message_spv/views/message_spv_view.xml
@@ -77,6 +77,38 @@
                         type="object"
                         invisible="message_type not in ('in_invoice','in_receipt')"
                     />
+                    <button
+                        name="action_download_attachment"
+                        string="ZIP"
+                        type="object"
+                        icon="fa-file-archive-o"
+                        invisible="not attachment_id"
+                        title="Download the signed ANAF ZIP"
+                    />
+                    <button
+                        name="action_download_xml"
+                        string="XML"
+                        type="object"
+                        icon="fa-file-code-o"
+                        invisible="not attachment_id"
+                        title="Download the invoice XML"
+                    />
+                    <button
+                        name="action_download_anaf_pdf"
+                        string="PDF ANAF"
+                        type="object"
+                        icon="fa-file-pdf-o"
+                        invisible="not attachment_id"
+                        title="Download the PDF rendered by ANAF"
+                    />
+                    <button
+                        name="action_download_embedded_pdf"
+                        string="PDF"
+                        type="object"
+                        icon="fa-paperclip"
+                        invisible="not attachment_id"
+                        title="Download the PDF embedded in the invoice XML"
+                    />
                 </header>
                 <sheet>
                     <group>
@@ -113,49 +145,6 @@
                             />
                         </group>
 
-                        <group string="Files">
-                            <label for="attachment_id" />
-                            <div name="attachment_div" class="o_row">
-                                <field name="attachment_id" />
-                                <button
-                                    name="action_download_attachment"
-                                    string="Download"
-                                    type="object"
-                                    invisible="not attachment_id"
-                                />
-                            </div>
-                            <label for="attachment_xml_id" />
-                            <div name="attachment_xml_div" class="o_row">
-                                <field name="attachment_xml_id" />
-                                <button
-                                    name="action_download_xml"
-                                    string="Download"
-                                    type="object"
-                                    invisible="not attachment_id"
-                                />
-                            </div>
-                            <label for="attachment_anaf_pdf_id" />
-                            <div name="attachment_anaf_pdf_div" class="o_row">
-                                <field name="attachment_anaf_pdf_id" />
-                                <button
-                                    name="action_download_anaf_pdf"
-                                    string="Download"
-                                    type="object"
-                                    invisible="not attachment_id"
-                                />
-                            </div>
-
-                            <label for="attachment_embedded_pdf_id" />
-                            <div name="attachment_embedded_pdf_div" class="o_row">
-                                <field name="attachment_embedded_pdf_id" />
-                                <button
-                                    name="action_download_embedded_pdf"
-                                    string="Download"
-                                    type="object"
-                                    invisible="not attachment_id"
-                                />
-                            </div>
-                        </group>
                         <group string="Errors and Info">
                             <field name="error" invisible="not error" />
                             <field name="message" invisible="not message" />


### PR DESCRIPTION
## Summary
- Clicking "Download embedded PDF" when the invoice XML has no embedded PDF now raises a user-friendly `UserError` instead of navigating to a raw 404 page from the on-the-fly controller route.
- The derived attachment fields (ZIP, XML, ANAF PDF, embedded PDF) are computed on demand and often have no file name to display. The form view no longer shows them as fields with a name; the four download actions are now buttons with suggestive icons in the form header instead.

## Test plan
- [x] `./odoo-bin -d o18_test -u l10n_ro_message_spv --test-tags=l10n_ro_message_spv --stop-after-init` → 24 tests, 0 failed, 0 errors
- [x] Manually verified in the browser: the header buttons (ZIP, XML, PDF ANAF, PDF) download correctly, and clicking the embedded-PDF button on an invoice without an embedded PDF shows a clean "Invalid Operation" dialog instead of a 404