### PR TITLE
[19.0][FIX] l10n_ro_city: avoid kwargs on UserError in onchange_zip

### DIFF
--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -53,7 +53,8 @@ class Partner(models.Model):
                 if self.state_id != state_b:
                     raise UserError(
                         self.env._(
-                            "The city %(city)s doesn't match the zip code and the state %(state)s",
+                            "The city %(city)s doesn't match"
+                            " the zip code and the state %(state)s",
                             city=city.name,
                             state=state_b.name,
                         )

--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -32,10 +32,7 @@ class Partner(models.Model):
             state = self.env["res.country.state"].search(domain, limit=1)
             if state:
                 if self.state_id and self.state_id != state:
-                    raise UserError(
-                        self.env._("The state {name} doesn't match the zip code"),
-                        name=state.name,
-                    )
+                    raise UserError(self.env._("The state %s doesn't match the zip code") % state.name)
                 self.state_id = state
 
             if self.zip[:2] in ["01", "02", "03", "04", "05", "06"]:
@@ -50,12 +47,8 @@ class Partner(models.Model):
                 city = self.env.ref(mapping[self.zip[:2]])
                 if self.state_id != state_b:
                     raise UserError(
-                        self.env._(
-                            "The city {city} doesn't match the"
-                            " zip code and the state {state}"
-                        ),
-                        city=city.name,
-                        state=state.name,
+                        self.env._("The city %s doesn't match the zip code and the state %s")
+                        % (city.name, state.name)
                     )
             else:
                 domain = [

--- a/l10n_ro_city/models/res_partner.py
+++ b/l10n_ro_city/models/res_partner.py
@@ -32,7 +32,12 @@ class Partner(models.Model):
             state = self.env["res.country.state"].search(domain, limit=1)
             if state:
                 if self.state_id and self.state_id != state:
-                    raise UserError(self.env._("The state %s doesn't match the zip code") % state.name)
+                    raise UserError(
+                        self.env._(
+                            "The state %(state)s doesn't match the zip code",
+                            state=state.name,
+                        )
+                    )
                 self.state_id = state
 
             if self.zip[:2] in ["01", "02", "03", "04", "05", "06"]:
@@ -47,8 +52,11 @@ class Partner(models.Model):
                 city = self.env.ref(mapping[self.zip[:2]])
                 if self.state_id != state_b:
                     raise UserError(
-                        self.env._("The city %s doesn't match the zip code and the state %s")
-                        % (city.name, state.name)
+                        self.env._(
+                            "The city %(city)s doesn't match the zip code and the state %(state)s",
+                            city=city.name,
+                            state=state_b.name,
+                        )
                     )
             else:
                 domain = [

--- a/l10n_ro_city/tests/test_ro_city.py
+++ b/l10n_ro_city/tests/test_ro_city.py
@@ -2,9 +2,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 
+from odoo.exceptions import UserError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
-from odoo.exceptions import UserError
 
 
 class TestRoCity(TransactionCase):

--- a/l10n_ro_city/tests/test_ro_city.py
+++ b/l10n_ro_city/tests/test_ro_city.py
@@ -4,6 +4,7 @@
 
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
 
 
 class TestRoCity(TransactionCase):
@@ -48,3 +49,12 @@ class TestRoCity(TransactionCase):
         partner_form.state_id = self.state_b
         partner_form.zip = "030011"
         self.assertEqual(partner_form.city_id.name, "Sector3")
+
+    def test_onchange_zip_state_mismatch_raises_usererror(self):
+        partner_form = Form(self.env["res.partner"])
+        partner_form.country_id = self.env.ref("base.ro")
+        partner_form.state_id = self.state_b
+
+        with self.assertRaises(UserError):
+            # 607185 belongs to BC while the partner state is B.
+            partner_form.zip = "607185"

--- a/l10n_ro_city/tests/test_ro_city.py
+++ b/l10n_ro_city/tests/test_ro_city.py
@@ -58,3 +58,12 @@ class TestRoCity(TransactionCase):
         with self.assertRaises(UserError):
             # 607185 belongs to BC while the partner state is B.
             partner_form.zip = "607185"
+
+    def test_onchange_zip_bucharest_sector_mismatch_raises_usererror(self):
+        partner_form = Form(self.env["res.partner"])
+        partner_form.country_id = self.env.ref("base.ro")
+        partner_form.state_id = self.state_bc
+
+        with self.assertRaises(UserError):
+            # 030011 belongs to Bucharest sectors and requires state B.
+            partner_form.zip = "030011"


### PR DESCRIPTION
## Problem
In `l10n_ro_city.models.res_partner.onchange_zip`, two `UserError` raises pass keyword arguments (`name=`, `city=`, `state=`) directly to `UserError`.

On Odoo 19 this crashes with:

`TypeError: UserError.__init__() got an unexpected keyword argument 'name'`

## Root cause
Formatting kwargs were intended for the translated string, but were passed to the exception constructor.

## Fix
- Build the final message string first.
- Raise `UserError(message)` with a single positional message argument.

## Impact
Fixes onchange ZIP flows that call `res.partner.onchange_zip()`, including delivery carrier details wizard flows.

## Notes
No behavior change besides removing the crash and showing the intended validation message.