### PR TITLE
[FIX] l10n_ro_message_spv: match draft vendor bills when deduplicating SPV downloads

### DIFF
--- a/l10n_ro_message_spv/README.rst
+++ b/l10n_ro_message_spv/README.rst
@@ -223,6 +223,16 @@ Configuration
 Changelog
 =========
 
+**19.0.2.1.2 (2026-07-09)**
+
+- Fixed duplicate vendor bills when a bill already exists in Odoo (e.g.
+  created from a purchase order) and is still in draft when the matching
+  invoice is later downloaded from SPV: the deduplication search used to
+  only match ``posted`` invoices, so a draft bill with the same
+  reference and vendor was never found, and a second draft bill was
+  created for the same document. The search now matches any
+  non-cancelled invoice.
+
 **19.0.2.1.1 (2026-07-05)**
 
 - Clicking "Download embedded PDF" when the invoice XML has no embedded

--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "19.0.2.3.0",
+    "version": "19.0.2.3.1",
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -421,7 +421,7 @@ class MessageSPV(models.Model):
         messages_with_ref = messages_without_invoice.filtered(lambda m: m.ref)
         domain = [("name", "in", messages_with_ref.mapped("ref"))]
         invoices |= self.env["account.move"].search(domain)
-        invoices = invoices.filtered(lambda i: i.state == "posted")
+        invoices = invoices.filtered(lambda i: i.state != "cancel")
         for message in messages_without_invoice:
             invoice = invoices.filtered(
                 lambda i, m=message: i.l10n_ro_edi_download == m.name
@@ -579,7 +579,7 @@ class MessageSPV(models.Model):
                 [
                     ("ref", "=", new_invoice.ref),
                     ("move_type", "in", ("in_invoice", "in_receipt")),
-                    ("state", "=", "posted"),
+                    ("state", "!=", "cancel"),
                     (
                         "commercial_partner_id",
                         "=",

--- a/l10n_ro_message_spv/readme/HISTORY.md
+++ b/l10n_ro_message_spv/readme/HISTORY.md
@@ -1,3 +1,12 @@
+**19.0.2.1.2 (2026-07-09)**
+
+- Fixed duplicate vendor bills when a bill already exists in Odoo (e.g.
+  created from a purchase order) and is still in draft when the matching
+  invoice is later downloaded from SPV: the deduplication search used to
+  only match `posted` invoices, so a draft bill with the same reference
+  and vendor was never found, and a second draft bill was created for the
+  same document. The search now matches any non-cancelled invoice.
+
 **19.0.2.1.1 (2026-07-05)**
 
 - Clicking "Download embedded PDF" when the invoice XML has no embedded


### PR DESCRIPTION
## Summary

When a vendor bill already exists in Odoo (e.g. created manually from a purchase order) and is still in `draft` state at the moment the matching invoice is downloaded from SPV, `message_spv.create_invoice()` was unable to find it: the deduplication search (and the earlier lookup in `get_invoice_from_move()`) only matched invoices in state `posted`. As a result a second draft bill was created for the same document instead of being linked to the existing one.

The search now matches any invoice that is not `cancel`, regardless of its state (`draft` or `posted`).

## Test plan

- [ ] Create a vendor bill manually from a purchase order and leave it in draft, with a `ref` matching a supplier invoice number.
- [ ] Download/import the matching invoice from SPV for the same partner and reference.
- [ ] Confirm the SPV message links to the existing draft bill instead of creating a duplicate draft bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)