### PR TITLE
[FIX] l10n_ro_fiscal_validation: fix ANAF bulk VAT sync result parsing

### DIFF
--- a/l10n_ro_fiscal_validation/models/res_partner.py
+++ b/l10n_ro_fiscal_validation/models/res_partner.py
@@ -66,6 +66,7 @@ class ResPartner(models.Model):
                         result = res.json()
                     except Exception:
                         _logger.warning(f"ANAF sync not working: {res.content}")
+
                     if result.get("correlationId"):
                         time.sleep(3)
                         resp = False
@@ -78,19 +79,22 @@ class ResPartner(models.Model):
                         except Exception as e:
                             _logger.warning(f"ANAF sync not working: {e}")
                         if resp and resp.status_code == 200:
-                            resp = resp.json()
-                            for result_partner in resp["found"] + resp["notfound"]:
-                                vat = result_partner.get("date_generale").get("cui")
-                                if vat:
-                                    partners = self.search(
-                                        [
-                                            ("l10n_ro_vat_number", "=", vat),
-                                            ("is_company", "=", True),
-                                        ]
-                                    )
-                                    for partner in partners:
-                                        data = partner._Anaf_to_Odoo(result_partner)
-                                        partner.update(data)
+                            result = resp.json()
+
+                    for result_partner in result.get("found", []) + result.get(
+                        "notFound", []
+                    ):
+                        vat = result_partner.get("date_generale").get("cui")
+                        if vat:
+                            partners = self.search(
+                                [
+                                    ("l10n_ro_vat_number", "=", vat),
+                                    ("is_company", "=", True),
+                                ]
+                            )
+                            for partner in partners:
+                                data = partner._Anaf_to_Odoo(result_partner)
+                                partner.update(data)
             except Exception as e:
                 _logger.warning(f"ANAF sync not working: {e}")
 


### PR DESCRIPTION
- issue description fix:  partner updates from the ANAF bulk VAT check were only processed inside the correlationId-polling success branch, and the response key was misspelled (notfound vs notFound), so results could be dropped or raise a KeyError. The change moves the found/notFound processing outside that branch and uses .get() with defaults.