### PR TITLE
[FIX] l10n_ro_stock_account: keep core _run_fifo float contract

### DIFF
--- a/l10n_ro_stock_account/models/fifo/product.py
+++ b/l10n_ro_stock_account/models/fifo/product.py
@@ -73,15 +73,44 @@ class ProductProduct(models.Model):
     def _run_fifo_value(self, quantity, lot=None, at_date=None, location=None):
         """Returns the total value for the next outgoing product base on the
         qty give as argument."""
-        fifo_list = self._run_fifo(
+        fifo_list = self._run_fifo_layers(
             quantity, lot=lot, at_date=at_date, location=location
         )
         total_value = sum(item["value"] for item in fifo_list)
         return total_value
 
     def _run_fifo(self, quantity, lot=None, at_date=None, location=None):
-        """Returns the value for the next outgoing product base on the qty
-        give as argument."""
+        """Returns the total *value* (float) for the next outgoing product
+        based on the qty given as argument.
+
+        This keeps the core ``_run_fifo`` contract: core callers
+        (``_run_fifo_batch``, ``account.move.line``, ``stock.move``,
+        ``stock.lot``) divide or assign the result as a float. The RO
+        ``fifo_per_location`` flow derives that value from the per-location
+        FIFO layers (see ``_run_fifo_layers``); every other case falls back
+        to core. This must not return a list, otherwise a RO product reaching
+        a core caller (e.g. in a multi-company read where the active company
+        has ``fifo_per_location`` set) crashes with ``list / float``.
+        """
+        self.ensure_one()
+        is_ro_fifo = (
+            self.env.company.fifo_per_location
+            and self.cost_method == "fifo"
+            and not self.lot_valuated
+        )
+        if not is_ro_fifo:
+            return super()._run_fifo(
+                quantity, lot=lot, at_date=at_date, location=location
+            )
+        return self._run_fifo_value(
+            quantity, lot=lot, at_date=at_date, location=location
+        )
+
+    def _run_fifo_layers(self, quantity, lot=None, at_date=None, location=None):
+        """Returns the list of FIFO layers (dicts with ``move_id``,
+        ``quantity``, ``value`` and ``description``) consumed to satisfy the
+        given outgoing ``quantity``. Used by ``_run_fifo_value`` and by the
+        outgoing move split (RO ``fifo_per_location`` flow)."""
         self.ensure_one()
         ro_fifo_products = self.filtered(
             lambda p: self.env.company.fifo_per_location
@@ -89,9 +118,16 @@ class ProductProduct(models.Model):
             and not p.lot_valuated
         )
         if not ro_fifo_products:
-            return super()._run_fifo(
-                quantity, lot=lot, at_date=at_date, location=location
-            )
+            return [
+                {
+                    "move_id": False,
+                    "quantity": quantity,
+                    "value": super()._run_fifo(
+                        quantity, lot=lot, at_date=at_date, location=location
+                    ),
+                    "description": self.display_name,
+                }
+            ]
         if self.uom_id.compare(quantity, 0) <= 0:
             return [
                 {

--- a/l10n_ro_stock_account/models/fifo/stock_move.py
+++ b/l10n_ro_stock_account/models/fifo/stock_move.py
@@ -278,12 +278,13 @@ class StockMove(models.Model):
         return res
 
     def _split_for_fifo_assignment(self):
-        """Splits moves based on FIFO list coming from product _run_fifo."""
+        """Splits moves based on FIFO list coming from product
+        _run_fifo_layers."""
         fifo_split_vals_list = []
         for move in self:
             fifo_list = move.product_id.with_context(
                 location=move.location_id.ids
-            )._run_fifo(move.product_qty, location=move.location_id)
+            )._run_fifo_layers(move.product_qty, location=move.location_id)
             quantity = move.product_qty
             while quantity >= move.quantity and fifo_list:
                 fifo_split_vals_list, quantity = self._l10n_ro_process_fifo_split(


### PR DESCRIPTION
The RO fifo_per_location override of product._run_fifo returned a list of FIFO layers, but core Odoo's _run_fifo returns a float total value that callers (_run_fifo_batch, account.move.line, stock.move, stock.lot) divide or assign. In a multi-company read, core _compute_value iterates all allowed companies and re-invokes _run_fifo per company, so a RO product could reach core _run_fifo_batch where 'value / quantity' crashed with TypeError: unsupported operand type(s) for /: 'list' and 'float'.

_run_fifo now returns a float (delegating to _run_fifo_value for RO products, super() otherwise). The layer list moved to a new _run_fifo_layers method, used by _run_fifo_value and by the outgoing move split.