### PR TITLE
[FIX] l10n_ro_message_spv: guard migration against missing legacy columns

### DIFF
--- a/l10n_ro_message_spv/migrations/19.0.2.0.0/pre-migrate.py
+++ b/l10n_ro_message_spv/migrations/19.0.2.0.0/pre-migrate.py
@@ -4,6 +4,7 @@
 import logging
 
 from odoo import SUPERUSER_ID, api
+from odoo.tools.sql import column_exists
 
 _logger = logging.getLogger(__name__)
 
@@ -21,6 +22,11 @@ def migrate(cr, version):
     - messages without an invoice: delete the derived files — they can be
       re-extracted from the ZIP at any time.
     """
+    # On databases that never stored these fields as plain columns there is
+    # nothing to clean up; skip so the migration stays idempotent.
+    if not column_exists(cr, "l10n_ro_message_spv", "attachment_xml_id"):
+        return
+
     # Relink derived attachments to the invoice for messages that have one,
     # so the computed fields keep finding them.
     cr.execute(


### PR DESCRIPTION
## Problem

The `19.0.2.0.0` pre-migration converts `attachment_xml_id`, `attachment_anaf_pdf_id` and `attachment_embedded_pdf_id` into computed, non-stored fields. Before doing so it relinks / cleans up the historical stored attachments that referenced those columns.

On databases that never materialized these fields as plain columns (e.g. upgraded straight from a version predating them), the first `UPDATE` fails and aborts the whole upgrade:

```
ERROR: column m.attachment_xml_id does not exist
LINE 6:  AND a.id IN (m.attachment_xml_id, m.attachment_ana...
```

## Fix

Guard the cleanup with `column_exists()` and return early when the legacy column is absent — there is nothing to relink or delete, and the trailing `DROP COLUMN IF EXISTS` is already idempotent.

Minimal, backwards-compatible change; databases that do have the stored columns migrate exactly as before.