### PR TITLE
[19.0][FIX] l10n_ro_stock_account: skip zero-quantity FIFO consumption on out moves

### DIFF
--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -124,6 +124,20 @@ Performance notes
 Changelog
 =========
 
+19.0.0.25.1
+-----------
+
+- Fix ``IndexError: list index out of range`` in
+  ``stock_move._l10n_ro_process_fifo_split`` when validating an outgoing
+  move. An incoming move with nothing left to consume (its valued
+  quantity is zero, for instance a reception corrected to 0 after
+  validation) still entered the per-location FIFO stack; ``_split``
+  returns no values for a quantity that is zero at the UoM rounding, so
+  indexing its result crashed the transfer. Such moves no longer enter
+  the stack, zero-quantity slices are skipped by the outgoing split, and
+  the quantities are compared with the UoM rounding instead of raw
+  floats.
+
 19.0.0.19.1
 -----------
 

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.0.25.0",
+    "version": "19.0.0.25.1",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/fifo/product.py
+++ b/l10n_ro_stock_account/models/fifo/product.py
@@ -107,10 +107,15 @@ class ProductProduct(models.Model):
         )
 
     def _run_fifo_layers(self, quantity, lot=None, at_date=None, location=None):
-        """Returns the list of FIFO layers (dicts with ``move_id``,
+        """Returns the list of quantity/value slices (dicts with ``move_id``,
         ``quantity``, ``value`` and ``description``) consumed to satisfy the
         given outgoing ``quantity``. Used by ``_run_fifo_value`` and by the
-        outgoing move split (RO ``fifo_per_location`` flow)."""
+        outgoing move split (RO ``fifo_per_location`` flow).
+
+        Despite the ``layers`` in the name, these are slices of the incoming
+        ``stock.move`` records making up the location stack: 19.0 values the
+        moves themselves (``stock.move.value``), there is no
+        ``stock.valuation.layer`` any more."""
         self.ensure_one()
         ro_fifo_products = self.filtered(
             lambda p: self.env.company.fifo_per_location
@@ -159,6 +164,14 @@ class ProductProduct(models.Model):
                 move_values["move_id"] = move.id
             rem_qty = move_values["quantity"]
             move_value = move_values["value"]
+            # A move in the stack can have nothing left to consume: an incoming
+            # move whose valued quantity is zero (all its lines excluded from
+            # valuation, or a quantity corrected to 0 after validation), or a
+            # quantity that rounds to zero in the product UoM. Skip it so the
+            # returned list stays free of zero-quantity entries - the outgoing
+            # move split cannot turn those into stock moves.
+            if self.uom_id.compare(rem_qty, 0) <= 0:
+                continue
             if rem_qty >= quantity:
                 reserved_qty = min(quantity, rem_qty)
                 fifo_list.append(
@@ -289,9 +302,13 @@ class ProductProduct(models.Model):
             move = moves_in[idx]
             idx += 1
             in_qty = move._get_valued_qty()
-            fifo_stack.append(move)
-            remaining_qty_on_first_stack_move = min(in_qty, fifo_stack_size)
-            fifo_stack_size -= in_qty
+            # Moves that value nothing (all lines excluded from valuation,
+            # quantity corrected to 0 after validation) must not enter the
+            # stack: they would be reported with a remaining quantity of zero.
+            if self.uom_id.compare(in_qty, 0) > 0:
+                fifo_stack.append(move)
+                remaining_qty_on_first_stack_move = min(in_qty, fifo_stack_size)
+                fifo_stack_size -= in_qty
             if self.uom_id.compare(fifo_stack_size, 0) > 0 and idx >= len(moves_in):
                 # We need to fetch more moves
                 current_offset += 1

--- a/l10n_ro_stock_account/models/fifo/stock_move.py
+++ b/l10n_ro_stock_account/models/fifo/stock_move.py
@@ -309,8 +309,18 @@ class StockMove(models.Model):
         """Processes the FIFO split for a given move."""
         fifo_item = fifo_list.pop(0)
         fifo_quantity = fifo_item["quantity"]
-        if fifo_quantity < quantity:
+        # A slice with nothing left to consume (a stack move with zero valued
+        # quantity, or a rounding residue) carries no value and cannot become
+        # a stock move: ``_split`` returns no values for a quantity that is
+        # zero at the UoM rounding. Drop it and keep consuming the next one.
+        if move.product_id.uom_id.compare(fifo_quantity, 0) <= 0:
+            return fifo_split_vals_list, quantity
+        if move.product_id.uom_id.compare(fifo_quantity, quantity) < 0:
             new_move_vals_list = move._split(fifo_quantity)
+            if not new_move_vals_list:
+                # Nothing could be split off; leave the quantity on the
+                # original move instead of losing it.
+                return fifo_split_vals_list, quantity
             new_move_vals_list[0].update(
                 {
                     "value_manual": fifo_item["value"],

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,3 +1,15 @@
+## 19.0.0.25.1
+
+- Fix `IndexError: list index out of range` in
+  `stock_move._l10n_ro_process_fifo_split` when validating an outgoing move.
+  An incoming move with nothing left to consume (its valued quantity is zero,
+  for instance a reception corrected to 0 after validation) still entered the
+  per-location FIFO stack; `_split` returns no values for a quantity that is
+  zero at the UoM rounding, so indexing its result crashed the transfer. Such
+  moves no longer enter the stack, zero-quantity slices are skipped by the
+  outgoing split, and the quantities are compared with the UoM rounding
+  instead of raw floats.
+
 ## 19.0.0.19.1
 
 - Fix `TypeError: '<' not supported between instances of 'bool' and 'str'` in

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -464,6 +464,21 @@ Inventory Valuation reports drop from O(N) queries to O(distinct
 </div>
 </div>
 <div class="section" id="section-1">
+<h2>19.0.0.25.1</h2>
+<ul class="simple">
+<li>Fix <tt class="docutils literal">IndexError: list index out of range</tt> in
+<tt class="docutils literal">stock_move._l10n_ro_process_fifo_split</tt> when validating an outgoing
+move. An incoming move with nothing left to consume (its valued
+quantity is zero, for instance a reception corrected to 0 after
+validation) still entered the per-location FIFO stack; <tt class="docutils literal">_split</tt>
+returns no values for a quantity that is zero at the UoM rounding, so
+indexing its result crashed the transfer. Such moves no longer enter
+the stack, zero-quantity slices are skipped by the outgoing split, and
+the quantities are compared with the UoM rounding instead of raw
+floats.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h2>19.0.0.19.1</h2>
 <ul class="simple">
 <li>Fix

--- a/l10n_ro_stock_account/tests/__init__.py
+++ b/l10n_ro_stock_account/tests/__init__.py
@@ -2,6 +2,7 @@ from . import common
 
 from . import test_ro_stock_fifo
 from . import test_ro_stock_fifo_correction
+from . import test_ro_stock_fifo_zero_qty
 from . import test_ro_stock_avg
 from . import test_stock_fifo_internal_transfer
 from . import test_stock_location

--- a/l10n_ro_stock_account/tests/test_ro_stock_fifo_zero_qty.py
+++ b/l10n_ro_stock_account/tests/test_ro_stock_fifo_zero_qty.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2026 NextERP Romania SRL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import tagged
+
+from .common import TestROStockCommon
+
+
+@tagged("post_install", "-at_install")
+class TestROStockFifoZeroQty(TestROStockCommon):
+    """An incoming move with nothing left to consume (its valued quantity is
+    zero) must not be split off from the outgoing move: ``_split`` returns no
+    values for a zero quantity, which used to raise ``IndexError: list index
+    out of range`` in ``_l10n_ro_process_fifo_split``.
+
+    ``_run_fifo_layers`` returns slices of the incoming moves making up the
+    location stack - 19.0 has no ``stock.valuation.layer`` any more."""
+
+    def _receive(self, qty, price, index):
+        self.create_purchase(
+            {
+                "currency_id": self.ron,
+                "partner_id": self.supplier_1,
+                "product_id": self.product_fifo,
+                "qty": qty,
+                "stock_qty": qty,
+                "inv_qty": qty,
+                "price": price,
+                "inv_price": price,
+                "index": index,
+            }
+        )
+        return self.env["stock.move"].search(
+            [
+                ("product_id", "=", self.product_fifo.id),
+                ("is_in", "=", True),
+                ("state", "=", "done"),
+                ("location_dest_id", "=", self.location.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+
+    def _deliver(self, qty, index):
+        sale = self.create_sale_order(
+            {
+                "currency_id": self.ron,
+                "partner_id": self.customer_1,
+                "product_id": self.product_fifo,
+                "qty": qty,
+                "stock_qty": qty,
+                "inv_qty": qty,
+                "price": 150,
+                "inv_price": 150,
+                "advance": 0,
+                "discount": 0,
+                "index": index,
+            }
+        )
+        return sale.picking_ids.move_ids.filtered(
+            lambda m: m.product_id == self.product_fifo and m.state == "done"
+        )
+
+    def _zero_out_reception(self, move):
+        """Correct a validated reception down to zero: the move stays done and
+        incoming, but it values nothing (``_get_valued_qty()`` is 0). Its stock
+        is given back, so it no longer backs any quant."""
+        line = move.move_line_ids[:1]
+        line.write({"quantity": 0})
+        move.invalidate_recordset(["quantity", "value"])
+        self.assertEqual(move.state, "done")
+        self.assertTrue(move.is_in)
+        self.assertAlmostEqual(move._get_valued_qty(), 0.0)
+        return move
+
+    def test_fifo_process_split_skips_zero_quantity_slice(self):
+        """``_l10n_ro_process_fifo_split`` must drop a zero-quantity slice and
+        keep consuming the next one, instead of raising IndexError."""
+        in_move = self._receive(10, 100, "zl_po")
+        out_move = self.env["stock.move"].create(
+            {
+                "product_id": self.product_fifo.id,
+                "product_uom_qty": 5,
+                "product_uom": self.product_fifo.uom_id.id,
+                "location_id": self.location.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "company_id": self.env.company.id,
+            }
+        )
+        out_move._action_confirm()
+        out_move._action_assign()
+        fifo_list = [
+            {
+                "move_id": False,
+                "quantity": 0.0,
+                "value": 0.0,
+                "description": "Nothing left to consume",
+            },
+            {
+                "move_id": in_move.id,
+                "quantity": 5.0,
+                "value": 500.0,
+                "description": in_move.display_name,
+            },
+        ]
+        # First slice: zero quantity -> skipped, nothing split off.
+        split_vals, quantity = self.env["stock.move"]._l10n_ro_process_fifo_split(
+            out_move, fifo_list, 5.0, []
+        )
+        self.assertEqual(
+            split_vals, [], "A zero-quantity slice must not generate a split move"
+        )
+        self.assertAlmostEqual(
+            quantity, 5.0, msg="The quantity left to assign must stay untouched"
+        )
+        self.assertEqual(len(fifo_list), 1, "The zero slice must be consumed")
+        self.assertAlmostEqual(out_move.product_uom_qty, 5.0)
+
+        # Second slice: covers the whole move -> valued, no split.
+        split_vals, quantity = self.env["stock.move"]._l10n_ro_process_fifo_split(
+            out_move, fifo_list, quantity, split_vals
+        )
+        self.assertEqual(split_vals, [])
+        self.assertAlmostEqual(quantity, 0.0)
+        self.assertAlmostEqual(out_move.value_manual, 500.0)
+
+    def test_fifo_out_move_with_zero_valued_reception_in_stack(self):
+        """An incoming move that values nothing must not show up in the FIFO
+        stack, and a delivery exceeding the stock must still validate."""
+        # Two receptions of 10 @ 100; the newer one is corrected down to 0.
+        self._receive(10, 100, "zl_po1")
+        self._zero_out_reception(self._receive(10, 100, "zl_po2"))
+        product_at_loc = self.product_fifo.with_context(
+            location=self.location.id, strict=True
+        )
+        self.assertAlmostEqual(
+            product_at_loc.qty_available,
+            10.0,
+            msg="Only the first reception is left in stock",
+        )
+
+        # No zero-quantity slice may reach the outgoing split.
+        slices = self.product_fifo.with_context(
+            location=self.location.ids
+        )._run_fifo_layers(15, location=self.location)
+        self.assertTrue(slices)
+        for fifo_slice in slices:
+            self.assertGreater(
+                fifo_slice["quantity"],
+                0,
+                f"No FIFO slice may have a zero quantity: {slices}",
+            )
+
+        # Delivering 15 with 10 on hand: 10 from the reception + 5 on negative
+        # stock, valued at the standard price.
+        out_moves = self._deliver(15, "zl_so")
+        self.assertTrue(out_moves, "The delivery must be validated")
+        self.assertAlmostEqual(sum(out_moves.mapped("quantity")), 15.0)
+        self.assertAlmostEqual(
+            sum(abs(value) for value in out_moves.mapped("value")),
+            10 * 100 + 5 * self.product_fifo.standard_price,
+        )


### PR DESCRIPTION
## Problem

Validating an outgoing move crashes when the per-location FIFO stack contains an incoming move that values nothing:

```
File ".../l10n_ro_stock_account/models/fifo/stock_move.py", line 150, in _action_done
    moves_out_fifo_splitted = ro_fifo_moves_out._split_for_fifo_assignment()
File ".../l10n_ro_stock_account/models/fifo/stock_move.py", line 290, in _split_for_fifo_assignment
    fifo_split_vals_list, quantity = self._l10n_ro_process_fifo_split(
File ".../l10n_ro_stock_account/models/fifo/stock_move.py", line 314, in _l10n_ro_process_fifo_split
    new_move_vals_list[0].update(
    ~~~~~~^^^
IndexError: list index out of range
```

## Cause

`_run_fifo_layers` returns the quantity/value slices of the incoming `stock.move` records making up the location stack — despite the `layers` in the name, 19.0 values the moves themselves (`stock.move.value`), there is no `stock.valuation.layer` any more.

One of those slices can have nothing left to consume: a reception whose quantity is corrected to `0` after validation stays `done` and `is_in` (its line is still picked), but its valued quantity is `0`. It still entered the per-location stack, so `_get_remaining_moves_ro` reported it with a remaining quantity of `0`:

```python
[{'move_id': 1, 'quantity': 10.0, 'value': 1000.0},
 {'move_id': 2, 'quantity': 0.0,  'value': 0.0},     # <-- values nothing
 {'move_id': False, 'quantity': 5.0, 'value': 500.0}]
```

`_l10n_ro_process_fifo_split` then asked `stock.move._split()` to split that zero quantity off the outgoing move. `_split` returns no values at all for a quantity that is zero at the UoM rounding, so indexing its first element raised, and the transfer could not be validated any more.

## Fix

- `_run_fifo_get_stack`: moves that value nothing no longer enter the FIFO stack.
- `_run_fifo_layers`: slices whose remaining quantity rounds to zero in the product UoM are skipped.
- `_l10n_ro_process_fifo_split`: zero-quantity slices are dropped instead of being split off, quantities are compared with the UoM rounding instead of raw floats (a rounding residue used to split the whole remaining quantity, leaving the original move at 0), and an empty `_split` result keeps the quantity on the original move.

## Tests

`tests/test_ro_stock_fifo_zero_qty.py`:

- `test_fifo_process_split_skips_zero_quantity_slice` — pins the traceback above: a zero-quantity slice must be dropped and the next one consumed.
- `test_fifo_out_move_with_zero_valued_reception_in_stack` — a reception corrected to `0` must not show up in the FIFO stack, and a delivery exceeding the stock must still validate (10 from the reception + 5 on negative stock at the standard price).

Both tests fail on 19.0 before the fix (`IndexError` and a `quantity: 0.0` slice) and pass after it. The whole `l10n_ro_stock_account` suite passes (22 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)