### PR TITLE
[19.0][FIX] l10n_ro_config: don't take the VAT country code from a database lookup

### DIFF
--- a/l10n_ro_config/README.rst
+++ b/l10n_ro_config/README.rst
@@ -99,6 +99,34 @@ Bank Accounts
   \*\* This applies also for company bank accounts, there you can use
   also the related field from Account Journal to mark them.
 
+Changelog
+=========
+
+19.0.0.8.1
+----------
+
+- Fix a foreign tax ID being silently prefixed with its country code on
+  every save, which made it impossible to store the number in its local
+  form. A Hungarian 11-digit adószám (``26173247-2-08``) became
+  ``HU26173247-2-08`` on create, and removing the prefix brought it back
+  on the next write. Since VIES only recognises the 8-digit EU form
+  (``HU26173247``), the intra-Community check kept answering
+  ``unassigned``, ``vies_valid`` stayed unset and the intra-Community
+  fiscal position was never selected, so the invoice was taxed at the
+  domestic rate instead of being exempt.
+- The cause was ``_split_vat`` deducing the country code from a database
+  lookup (``search([("vat", "=", vat)])``): during create/write the
+  record is already stored when ``_check_vat`` runs, so it matched
+  itself and ``_run_vat_checks`` re-attached the prefix. The country
+  code is now taken from the record being parsed, and only for a bare
+  numeric CUI, so writing a Romanian CUI without the ``RO`` prefix keeps
+  working.
+- Dropping the lookup also removes one ``search`` per ``_split_vat``
+  call - the method is used by ``_compute_l10n_ro_vat_number`` and by
+  several core and Enterprise localisations - and the non-deterministic
+  result when the same ``vat`` string existed on partners from different
+  countries (``limit=1`` picked one arbitrarily).
+
 Bug Tracker
 ===========
 

--- a/l10n_ro_config/models/res_partner.py
+++ b/l10n_ro_config/models/res_partner.py
@@ -37,12 +37,25 @@ class ResPartner(models.Model):
         return country_code_map.get(country_code, country_code)
 
     def _split_vat(self, vat):
+        """Allow the Romanian CUI to be written without the "RO" prefix.
+
+        The country code is taken from the current record, never from a database
+        lookup. A previous implementation searched for a partner having the same
+        ``vat`` and borrowed its country code: during create/write the record is
+        already in the database when ``_check_vat`` runs, so it found itself and
+        ``_run_vat_checks`` re-attached the prefix. That made it impossible to
+        store a tax ID without its country prefix - for instance a Hungarian
+        11-digit adoszam, which VIES only accepts in its 8-digit EU form.
+        """
         vat_country, l10n_ro_vat_number = super()._split_vat(vat)
-        partner = self.search([("vat", "=", vat)], limit=1)
-        if partner and partner.country_id and partner.country_id.code:
-            vat_country = self._l10n_ro_map_vat_country_code(
-                partner.country_id.code.upper()
-            ).upper()
+        if vat_country or not vat or not vat.isdigit():
+            return vat_country, l10n_ro_vat_number
+        country_code = self.country_id.code if len(self) == 1 else False
+        if (
+            country_code
+            and self._l10n_ro_map_vat_country_code(country_code.upper()) == "RO"
+        ):
+            vat_country = "RO"
         return vat_country, l10n_ro_vat_number
 
     def _get_ro_vat(self):

--- a/l10n_ro_config/readme/HISTORY.md
+++ b/l10n_ro_config/readme/HISTORY.md
@@ -1,0 +1,21 @@
+## 19.0.0.8.1
+
+- Fix a foreign tax ID being silently prefixed with its country code on every
+  save, which made it impossible to store the number in its local form. A
+  Hungarian 11-digit adószám (`26173247-2-08`) became `HU26173247-2-08` on
+  create, and removing the prefix brought it back on the next write. Since VIES
+  only recognises the 8-digit EU form (`HU26173247`), the intra-Community check
+  kept answering `unassigned`, `vies_valid` stayed unset and the
+  intra-Community fiscal position was never selected, so the invoice was taxed
+  at the domestic rate instead of being exempt.
+- The cause was `_split_vat` deducing the country code from a database lookup
+  (`search([("vat", "=", vat)])`): during create/write the record is already
+  stored when `_check_vat` runs, so it matched itself and `_run_vat_checks`
+  re-attached the prefix. The country code is now taken from the record being
+  parsed, and only for a bare numeric CUI, so writing a Romanian CUI without
+  the `RO` prefix keeps working.
+- Dropping the lookup also removes one `search` per `_split_vat` call - the
+  method is used by `_compute_l10n_ro_vat_number` and by several core and
+  Enterprise localisations - and the non-deterministic result when the same
+  `vat` string existed on partners from different countries (`limit=1` picked
+  one arbitrarily).

--- a/l10n_ro_config/static/description/index.html
+++ b/l10n_ro_config/static/description/index.html
@@ -396,11 +396,15 @@ on a Romanian company, otherwise the are hidden.</p>
 <li><a class="reference internal" href="#bank-accounts" id="toc-entry-6">Bank Accounts</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-7">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-8">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-9">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-10">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-7">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-8">19.0.0.8.1</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-9">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-10">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-11">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-12">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-13">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -457,8 +461,37 @@ also the related field from Account Journal to mark them.</p>
 </ul>
 </div>
 </div>
+<div class="section" id="changelog">
+<h2><a class="toc-backref" href="#toc-entry-7">Changelog</a></h2>
+<div class="section" id="section-1">
+<h3><a class="toc-backref" href="#toc-entry-8">19.0.0.8.1</a></h3>
+<ul class="simple">
+<li>Fix a foreign tax ID being silently prefixed with its country code on
+every save, which made it impossible to store the number in its local
+form. A Hungarian 11-digit adószám (<tt class="docutils literal"><span class="pre">26173247-2-08</span></tt>) became
+<tt class="docutils literal"><span class="pre">HU26173247-2-08</span></tt> on create, and removing the prefix brought it back
+on the next write. Since VIES only recognises the 8-digit EU form
+(<tt class="docutils literal">HU26173247</tt>), the intra-Community check kept answering
+<tt class="docutils literal">unassigned</tt>, <tt class="docutils literal">vies_valid</tt> stayed unset and the intra-Community
+fiscal position was never selected, so the invoice was taxed at the
+domestic rate instead of being exempt.</li>
+<li>The cause was <tt class="docutils literal">_split_vat</tt> deducing the country code from a database
+lookup (<tt class="docutils literal"><span class="pre">search([(&quot;vat&quot;,</span> <span class="pre">&quot;=&quot;,</span> <span class="pre">vat)])</span></tt>): during create/write the
+record is already stored when <tt class="docutils literal">_check_vat</tt> runs, so it matched
+itself and <tt class="docutils literal">_run_vat_checks</tt> re-attached the prefix. The country
+code is now taken from the record being parsed, and only for a bare
+numeric CUI, so writing a Romanian CUI without the <tt class="docutils literal">RO</tt> prefix keeps
+working.</li>
+<li>Dropping the lookup also removes one <tt class="docutils literal">search</tt> per <tt class="docutils literal">_split_vat</tt>
+call - the method is used by <tt class="docutils literal">_compute_l10n_ro_vat_number</tt> and by
+several core and Enterprise localisations - and the non-deterministic
+result when the same <tt class="docutils literal">vat</tt> string existed on partners from different
+countries (<tt class="docutils literal">limit=1</tt> picked one arbitrarily).</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-7">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-romania/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -466,16 +499,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-8">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-10">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-9">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-11">Authors</a></h3>
 <ul class="simple">
 <li>NextERP Romania</li>
 <li>Forest and Biomass Romania</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-10">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-12">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.nexterp.ro">NextERP Romania</a>:<ul>
 <li>Fekete Mihai &lt;<a class="reference external" href="mailto:feketemihai&#64;nexterp.ro">feketemihai&#64;nexterp.ro</a>&gt;</li>
@@ -495,7 +528,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 technical issues.</p>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-13">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/l10n_ro_config/tests/__init__.py
+++ b/l10n_ro_config/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_bank_account_print_report
 from . import test_partner_country_code
 from . import test_l10n_ro_hide
+from . import test_partner_vat_foreign_prefix

--- a/l10n_ro_config/tests/test_partner_vat_foreign_prefix.py
+++ b/l10n_ro_config/tests/test_partner_vat_foreign_prefix.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 Terrabit Solutions
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestPartnerVatForeignPrefix(AccountTestInvoicingCommon):
+    """A foreign tax ID must keep the exact form it was entered with.
+
+    ``_split_vat`` used to look up a partner having the same ``vat`` and borrow
+    its country code. During create/write the record is already in the database
+    when ``_check_vat`` runs, so it matched itself and ``_run_vat_checks``
+    re-attached the country prefix - the user could never store the local form
+    of the number.
+    """
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country("ro")
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.l10n_ro_accounting = True
+        cls.env.companies.vat_check_vies = False
+        cls.country_hu = cls.env.ref("base.hu")
+        # Hungarian adoszam: 8 digits + VAT code + county code. The EU form used
+        # by VIES is the prefix plus the first 8 digits only.
+        cls.local_vat = "26173247-2-08"
+        cls.eu_vat = "HU26173247"
+
+    def _create_hu_partner(self, vat):
+        return self.env["res.partner"].create(
+            {
+                "name": "Hungarian Partner",
+                "is_company": True,
+                "country_id": self.country_hu.id,
+                "vat": vat,
+            }
+        )
+
+    def test_local_vat_kept_without_prefix(self):
+        partner = self._create_hu_partner(self.local_vat)
+        self.assertEqual(partner.vat, self.local_vat)
+
+    def test_local_vat_without_separators_kept(self):
+        partner = self._create_hu_partner("26173247208")
+        self.assertFalse(partner.vat.startswith("HU"))
+
+    def test_eu_vat_kept_with_prefix(self):
+        partner = self._create_hu_partner(self.eu_vat)
+        self.assertEqual(partner.vat, self.eu_vat)
+
+    def test_prefix_removal_survives_write(self):
+        partner = self._create_hu_partner(self.eu_vat)
+        partner.write({"vat": self.local_vat})
+        self.assertEqual(partner.vat, self.local_vat)
+
+    def test_split_vat_does_not_borrow_country_from_database(self):
+        """A second partner must not inherit the first one's country code."""
+        self._create_hu_partner(self.local_vat)
+        other = self.env["res.partner"].create(
+            {"name": "No Country Partner", "is_company": True}
+        )
+        self.assertEqual(other._split_vat(self.local_vat), ("", self.local_vat))
+
+    def test_ro_cui_without_prefix_still_resolves_to_ro(self):
+        """The Romanian shortcut must keep working: bare digits mean RO."""
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Romanian Partner",
+                "is_company": True,
+                "country_id": self.env.ref("base.ro").id,
+                "vat": "4264242",
+            }
+        )
+        self.assertEqual(partner._split_vat("4264242"), ("RO", "4264242"))


### PR DESCRIPTION
## Problem

`_split_vat` deduces the country code from a **database lookup**:

```python
def _split_vat(self, vat):
    vat_country, l10n_ro_vat_number = super()._split_vat(vat)
    partner = self.search([("vat", "=", vat)], limit=1)
    if partner and partner.country_id and partner.country_id.code:
        vat_country = self._l10n_ro_map_vat_country_code(
            partner.country_id.code.upper()).upper()
```

During create/write the record is already stored when `_check_vat` runs, so the
search **matches the record itself**, and `base_vat._run_vat_checks` then treats
the borrowed code as a prefix the user had typed and re-attaches it. A foreign
tax ID can therefore never be stored in its local form.

Reproduced on 19.0 with a Hungarian partner:

| entered | stored |
|---|---|
| `26173247-2-08` | `HU26173247-2-08` |
| `26173247208` | `HU26173247-2-08` |
| `26173247` | `HU26173247` |

Removing the prefix by hand brings it back on the next write.

This matters beyond cosmetics. The Hungarian adószám has 11 digits
(`26173247-2-08`), while the EU form VIES recognises is the prefix plus the
first 8 digits (`HU26173247`). `check_vat_hu` accepts both, so nothing is
flagged - but `_check_vies_iap` sends `self.vat` verbatim, VIES answers
`unassigned`, `vies_valid` stays unset, the intra-Community fiscal position is
never selected and an exempt intra-Community supply gets taxed at the domestic
rate.

## Regression from 18.0

The 18.0 implementation only did the lookup for `vat.isdigit()` and returned a
lowercased code, so a number containing separators never reached it, and
`base_vat._fix_vat_number` bailed out early on `code.lower() != vat_country`.
Both guards disappeared in 19.0, and `_run_vat_checks` compares against the
uppercase codes of `res.country`, so the borrowed prefix now sticks.

Verified with `_fix_vat_number("26173247-2-08", hu_country_id)` on 18.0: the
value is returned unchanged.

## Fix

The country code is taken from the record being parsed, never from the
database, and only for a bare numeric CUI - so the Romanian convenience of
writing the CUI without the `RO` prefix keeps working.

Dropping the lookup also removes one `search` per `_split_vat` call - the method
is used by `_compute_l10n_ro_vat_number` and by several core and Enterprise
localisations (`l10n_ro_saft`, `l10n_pl_edi`, `l10n_be`, `l10n_dk`, `l10n_se`,
`l10n_cz_reports`, `l10n_de_reports`, ...) - and the non-deterministic result
when the same `vat` string exists on partners from different countries
(`limit=1` picked one arbitrarily).

## Tests

`test_partner_vat_foreign_prefix.py` covers: the local form survives create and
survives a write that removes the prefix, the EU form keeps its prefix, a
second partner does not inherit the first one's country code, and a bare
Romanian CUI still resolves to `RO`.

Run against the **unfixed** code, 3 of the 6 new tests fail
(`'HU26173247-2-08' != '26173247-2-08'`); with the fix the whole module suite is
green (21 tests, 0 failed, 0 errors), including the existing
`test_onchange_l10n_ro_vat_subjected`, which asserts that
`_split_vat("4264242")` still returns `("RO", "4264242")`.

## Note

No version bump included - left to `ocabot merge patch`. `readme/HISTORY.md`
is written for `19.0.0.8.1`.
