### PR TITLE
[19.0][FIX] l10n_ro_stock_report: split the storage sheet by valued type again

### DIFF
--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -124,6 +124,14 @@ Performance notes
 Changelog
 =========
 
+19.0.0.26.1
+-----------
+
+- Expose the ``stock.move.l10n_ro_move_type`` selection as the module
+  level ``MOVE_TYPE`` constant, so other modules can reuse it instead of
+  duplicating the list. Up to 18.0 the same list was available as
+  ``VALUED_TYPE`` on ``stock.valuation.layer``. No functional change.
+
 19.0.0.25.1
 -----------
 

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.0.26.0",
+    "version": "19.0.0.26.1",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -11,6 +11,35 @@ from odoo.tools.sql import column_exists, create_column
 
 _logger = logging.getLogger(__name__)
 
+# Kept as a module level constant so that other modules can reuse it; up to 18.0
+# the same list lived on stock.valuation.layer as VALUED_TYPE, and the storage
+# sheet report imported it from there.
+MOVE_TYPE = [
+    ("reception", "Reception"),
+    ("reception_return", "Reception Return"),
+    ("reception_notice", "Reception Notice"),
+    ("reception_notice_return", "Reception Notice Return"),
+    ("reception_in_progress", "Reception In Progress"),
+    ("reception_in_progress_return", "Reception In Progress Return"),
+    ("delivery", "Delivery"),
+    ("delivery_return", "Delivery Return"),
+    ("delivery_notice", "Delivery Notice"),
+    ("delivery_notice_return", "Delivery Notice Return"),
+    ("plus_inventory", "Plus Inventory"),
+    ("minus_inventory", "Minus Inventory"),
+    ("consumption", "Consumption"),
+    ("consumption_return", "Consumption Return"),
+    ("usage_giving", "Usage Giving"),
+    ("usage_giving_return", "Usage Giving Return"),
+    ("production", "Production"),
+    ("production_return", "Production Return"),
+    ("internal_transfer", "Internal Transfer"),
+    ("internal_transit_out", "Internal Transit Out"),
+    ("internal_transit_in", "Internal Transit In"),
+    ("dropshipped", "Dropshipped"),
+    ("dropshipped_return", "Dropshipped Return"),
+]
+
 
 class StockMove(models.Model):
     _name = "stock.move"
@@ -24,31 +53,7 @@ class StockMove(models.Model):
         copy=False,
     )
     l10n_ro_move_type = fields.Selection(
-        [
-            ("reception", "Reception"),
-            ("reception_return", "Reception Return"),
-            ("reception_notice", "Reception Notice"),
-            ("reception_notice_return", "Reception Notice Return"),
-            ("reception_in_progress", "Reception In Progress"),
-            ("reception_in_progress_return", "Reception In Progress Return"),
-            ("delivery", "Delivery"),
-            ("delivery_return", "Delivery Return"),
-            ("delivery_notice", "Delivery Notice"),
-            ("delivery_notice_return", "Delivery Notice Return"),
-            ("plus_inventory", "Plus Inventory"),
-            ("minus_inventory", "Minus Inventory"),
-            ("consumption", "Consumption"),
-            ("consumption_return", "Consumption Return"),
-            ("usage_giving", "Usage Giving"),
-            ("usage_giving_return", "Usage Giving Return"),
-            ("production", "Production"),
-            ("production_return", "Production Return"),
-            ("internal_transfer", "Internal Transfer"),
-            ("internal_transit_out", "Internal Transit Out"),
-            ("internal_transit_in", "Internal Transit In"),
-            ("dropshipped", "Dropshipped"),
-            ("dropshipped_return", "Dropshipped Return"),
-        ],
+        MOVE_TYPE,
         compute="_compute_l10n_ro_move_type",
         store=True,
         string="Romanian - Move Type",

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,3 +1,10 @@
+## 19.0.0.26.1
+
+- Expose the `stock.move.l10n_ro_move_type` selection as the module level
+  `MOVE_TYPE` constant, so other modules can reuse it instead of duplicating the
+  list. Up to 18.0 the same list was available as `VALUED_TYPE` on
+  `stock.valuation.layer`. No functional change.
+
 ## 19.0.0.25.1
 
 - Fix `IndexError: list index out of range` in

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -464,6 +464,15 @@ Inventory Valuation reports drop from O(N) queries to O(distinct
 </div>
 </div>
 <div class="section" id="section-1">
+<h2>19.0.0.26.1</h2>
+<ul class="simple">
+<li>Expose the <tt class="docutils literal">stock.move.l10n_ro_move_type</tt> selection as the module
+level <tt class="docutils literal">MOVE_TYPE</tt> constant, so other modules can reuse it instead of
+duplicating the list. Up to 18.0 the same list was available as
+<tt class="docutils literal">VALUED_TYPE</tt> on <tt class="docutils literal">stock.valuation.layer</tt>. No functional change.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h2>19.0.0.25.1</h2>
 <ul class="simple">
 <li>Fix <tt class="docutils literal">IndexError: list index out of range</tt> in
@@ -478,7 +487,7 @@ the quantities are compared with the UoM rounding instead of raw
 floats.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h2>19.0.0.19.1</h2>
 <ul class="simple">
 <li>Fix

--- a/l10n_ro_stock_report/README.rst
+++ b/l10n_ro_stock_report/README.rst
@@ -51,6 +51,23 @@ To install this module, you need to:
 - search for "Romania - Stock Report" in your addons
 - install the module
 
+Changelog
+=========
+
+19.0.2.4.1
+----------
+
+- Fix the storage sheet no longer splitting by valued type. Up to 18.0
+  the valued type of a line came from the valuation layer
+  (``svl.l10n_ro_valued_type``); Odoo 19 removed
+  ``stock.valuation.layer`` and moved the valuation onto ``stock.move``,
+  so the report hardcoded ``'indefinite'`` on every movement row and
+  grouping by "Valued Type" collapsed into a single group. The in/out
+  queries now read the stored ``stock_move.l10n_ro_move_type`` column
+  and group by it, and the line's selection lists every move type again
+  so the values are groupable and readable. Balance rows keep no valued
+  type, as in 18.0, since a balance aggregates several move types.
+
 Bug Tracker
 ===========
 

--- a/l10n_ro_stock_report/__manifest__.py
+++ b/l10n_ro_stock_report/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "Romania - Stock Report (Fișă Magazie)",
     "license": "AGPL-3",
-    "version": "19.0.2.4.0",
+    "version": "19.0.2.4.1",
     "countries": ["ro"],
     "author": "Terrabit,NextERP Romania,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",

--- a/l10n_ro_stock_report/readme/HISTORY.md
+++ b/l10n_ro_stock_report/readme/HISTORY.md
@@ -1,0 +1,12 @@
+## 19.0.2.4.1
+
+- Fix the storage sheet no longer splitting by valued type. Up to 18.0 the
+  valued type of a line came from the valuation layer
+  (`svl.l10n_ro_valued_type`); Odoo 19 removed `stock.valuation.layer` and moved
+  the valuation onto `stock.move`, so the report hardcoded `'indefinite'` on
+  every movement row and grouping by "Valued Type" collapsed into a single
+  group. The in/out queries now read the stored
+  `stock_move.l10n_ro_move_type` column and group by it, and the line's
+  selection lists every move type again so the values are groupable and
+  readable. Balance rows keep no valued type, as in 18.0, since a balance
+  aggregates several move types.

--- a/l10n_ro_stock_report/report/stock_report.py
+++ b/l10n_ro_stock_report/report/stock_report.py
@@ -9,8 +9,18 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
-# Local fallback; in v19 we do not depend on l10n_ro_stock_account
-VALUED_TYPE = [("indefinite", "Indefinite")]
+from odoo.addons.l10n_ro_stock_account.models.stock_move import MOVE_TYPE
+
+# Up to 18.0 the valued type of a report line came from the valuation layer
+# (svl.l10n_ro_valued_type). Odoo 19 removed stock.valuation.layer and moved the
+# valuation onto stock.move, so the same information is read from the stored
+# stock.move.l10n_ro_move_type column. "indefinite" stays as the fallback for
+# moves whose type could not be determined.
+VALUED_TYPE = MOVE_TYPE + [("indefinite", "Indefinite")]
+
+# Movement rows take the valued type from the move; it is not an aggregate, so
+# it has to appear in the GROUP BY of the in/out queries as well.
+VALUED_TYPE_SQL = "COALESCE(sm.l10n_ro_move_type, 'indefinite')"
 
 _logger = logging.getLogger(__name__)
 
@@ -391,7 +401,7 @@ class StorageSheet(models.TransientModel):
             %(location)s as location_id,
             sp.partner_id,
             sm.reference as document,
-            'indefinite' as valued_type,
+            {VALUED_TYPE_SQL} as valued_type,
             pt.categ_id as categ_id
             {select}
 
@@ -413,6 +423,7 @@ class StorageSheet(models.TransientModel):
         GROUP BY sm.product_id, sm.date, sm.reference,
                 sp.partner_id, sm.l10n_ro_account_id,
                 sm.l10n_ro_transfer_account_id,
+                {VALUED_TYPE_SQL},
                 pt.categ_id {group}
         """
         return sql
@@ -445,7 +456,7 @@ class StorageSheet(models.TransientModel):
             %(location)s as location_id,
             sp.partner_id,
             sm.reference as document,
-            'indefinite' as valued_type,
+            {VALUED_TYPE_SQL} as valued_type,
             pt.categ_id as categ_id
             {select}
 
@@ -466,6 +477,7 @@ class StorageSheet(models.TransientModel):
 
         GROUP BY sm.product_id, sm.date, sm.reference,
                 sp.partner_id, sm.l10n_ro_account_id,  sm.l10n_ro_transfer_account_id,
+                {VALUED_TYPE_SQL},
                 pt.categ_id {group}
         """
         return sql

--- a/l10n_ro_stock_report/static/description/index.html
+++ b/l10n_ro_stock_report/static/description/index.html
@@ -380,11 +380,15 @@ ul.auto-toc {
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-2">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-3">19.0.2.4.1</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -401,8 +405,26 @@ ul.auto-toc {
 <li>install the module</li>
 </ul>
 </div>
+<div class="section" id="changelog">
+<h2><a class="toc-backref" href="#toc-entry-2">Changelog</a></h2>
+<div class="section" id="section-1">
+<h3><a class="toc-backref" href="#toc-entry-3">19.0.2.4.1</a></h3>
+<ul class="simple">
+<li>Fix the storage sheet no longer splitting by valued type. Up to 18.0
+the valued type of a line came from the valuation layer
+(<tt class="docutils literal">svl.l10n_ro_valued_type</tt>); Odoo 19 removed
+<tt class="docutils literal">stock.valuation.layer</tt> and moved the valuation onto <tt class="docutils literal">stock.move</tt>,
+so the report hardcoded <tt class="docutils literal">'indefinite'</tt> on every movement row and
+grouping by “Valued Type” collapsed into a single group. The in/out
+queries now read the stored <tt class="docutils literal">stock_move.l10n_ro_move_type</tt> column
+and group by it, and the line’s selection lists every move type again
+so the values are groupable and readable. Balance rows keep no valued
+type, as in 18.0, since a balance aggregates several move types.</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-romania/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -410,16 +432,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-3">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-4">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Authors</a></h3>
 <ul class="simple">
 <li>Terrabit</li>
 <li>NextERP Romania</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-5">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.terrabit.ro">Terrabit</a>:<ul>
 <li>Dorin Hongu &lt;<a class="reference external" href="mailto:dhongu&#64;gmail.com">dhongu&#64;gmail.com</a>&gt;</li>
@@ -436,7 +458,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 technical issues.</p>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/l10n_ro_stock_report/tests/test_report_stock.py
+++ b/l10n_ro_stock_report/tests/test_report_stock.py
@@ -392,3 +392,53 @@ class TestStockReport(TransactionCase):
         self.assertEqual(qty_in_2, 10)
         self.assertEqual(qty_out_2, 4)
         self.assertEqual(qty_final_2, 8)
+
+    def test_report_valued_type_from_move_type(self):
+        """The valued type of a movement line comes from the move type.
+
+        Up to 18.0 it was read from the valuation layer; since that layer is gone
+        in 19.0 the report has to read stock.move.l10n_ro_move_type, otherwise
+        every line falls into a single "Indefinite" group.
+        """
+        product = self.product_1
+        date_dt = fields.Datetime.now() - timedelta(days=5)
+        date_from = fields.Datetime.now() - timedelta(days=10)
+        date_to = fields.Datetime.now() - timedelta(days=1)
+
+        receipt = self._create_receipt(product, 6, date_dt)
+        delivery = self._create_delivery(product, 2, date_dt)
+        self.assertEqual(receipt.move_ids.l10n_ro_move_type, "reception")
+        self.assertEqual(delivery.move_ids.l10n_ro_move_type, "delivery")
+
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.location_id = self.location
+        wizard.product_ids = product
+        wizard.date_from = date_from.date()
+        wizard.date_to = date_to.date()
+        wizard = wizard.save()
+        wizard.button_show_sheet_pdf()
+
+        lines = self.env["l10n.ro.stock.storage.sheet.line"].search(
+            [
+                ("report_id", "=", wizard.id),
+                ("product_id", "=", product.id),
+                ("location_id", "=", self.location.id),
+            ]
+        )
+        lines_in = lines.filtered(lambda line: line.quantity_in)
+        lines_out = lines.filtered(lambda line: line.quantity_out)
+        self.assertTrue(lines_in)
+        self.assertTrue(lines_out)
+        self.assertEqual(set(lines_in.mapped("valued_type")), {"reception"})
+        self.assertEqual(set(lines_out.mapped("valued_type")), {"delivery"})
+
+        # Movement types must be part of the selection, otherwise the values
+        # cannot be grouped nor read in the user interface.
+        selection = dict(
+            self.env["l10n.ro.stock.storage.sheet.line"]
+            ._fields["valued_type"]
+            .selection
+        )
+        self.assertIn("reception", selection)
+        self.assertIn("delivery", selection)
+        self.assertIn("indefinite", selection)


### PR DESCRIPTION
Grouping the storage sheet (Fișă Magazie) by **Valued Type** collapses into a single *Indefinite* group on 19.0, so the report no longer separates receptions from deliveries, productions, consumptions and so on. Reported by a customer on production.

## Cause

Up to 18.0 the valued type of a report line came from the valuation layer (`svl.l10n_ro_valued_type`), and this module imported the `VALUED_TYPE` selection from `l10n_ro_stock_account`.

Odoo 19 removed `stock.valuation.layer` and moved the valuation onto `stock.move`. The port replaced that import with a local `[("indefinite", "Indefinite")]` fallback and hardcoded `indefinite as valued_type` in the input and output queries, so every movement row ends up in the same group.

## Fix

`l10n_ro_stock_account` carries the same information on the stored `stock_move.l10n_ro_move_type` column:

- the in/out queries select `COALESCE(sm.l10n_ro_move_type, 'indefinite')` and group by it;
- the report line's `valued_type` selection lists the move types again, so the values are groupable and readable in the UI;
- the selection of `stock.move.l10n_ro_move_type` is exposed as the module level `MOVE_TYPE` constant instead of being duplicated — this mirrors what `VALUED_TYPE` was up to 18.0.

Balance rows are left untouched: they select no valued type on 19.0 and did not on 18.0 either, since a balance aggregates several move types.

## Tests

`test_report_valued_type_from_move_type` asserts that a reception line and a delivery line carry their own move type, and that the values are part of the selection. It **fails on the current code** (`{"indefinite"} != {"reception"}`) and passes with the fix.

Full suite of both touched modules: 0 failed, 0 errors.

Verified additionally on a copy of a customer database on 19.0: a month of movements for 16 products went from a single *Indefinite* group to 8 groups (consumption, delivery, delivery_return, internal_transfer, minus_inventory, plus_inventory, production, reception), with no change in the number of report lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)