### PR TITLE
Fix refresh days lookup in l10n_ro_message_spv

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -723,8 +723,9 @@ class MessageSPV(models.Model):
                 message.write({"partner_id": partner.id})
 
     def refresh(self):
-        get_param = self.env["ir.config_parameter"].sudo().get_param
-        l10n_ro_refresh_message_days = int(get_param("l10n_ro_refresh_message_days", 1))
+        l10n_ro_refresh_message_days = int(
+            self.env.company.l10n_ro_refresh_message_days or 1
+        )
         self.env.company._l10n_ro_download_message_spv(
             no_days=l10n_ro_refresh_message_days
         )

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -132,7 +132,7 @@ class ResCompany(models.Model):
             domain = [("company_id", "=", company.id), ("message_type", "=", "error")]
             error_messages = obj_message_spv.with_company(company).search(domain)
             error_messages.unlink()
-            days = no_days or company.l10n_ro_download_einvoices_days or no_days
+            days = no_days or int(company.l10n_ro_download_einvoices_days or 1)
             # company_messages = company._l10n_ro_get_anaf_efactura_messages()
             company_messages = obj_edi_document._request_ciusro_download_messages_spv(
                 company, no_days=days


### PR DESCRIPTION
- Use company.l10n_ro_refresh_message_days field instead of ir.config_parameter in MessageSPV.refresh()
- Cast l10n_ro_download_einvoices_days to int with default of 1 when computing no_days in _l10n_ro_download_message_spv