### PR TITLE
[18.0][REF] l10n_ro_stock_account: share the revaluation helper with the tracking module

### DIFF
--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -367,13 +367,15 @@ class StockMove(models.Model):
                 aggregates=["value:sum", "quantity:sum"],
             )
         )
-        if not groups:
+        # An account holding nothing for this product sums to no quantity at
+        # all (`None` over an empty set), in which case there is no per account
+        # cost to use and the standard valuation applies.
+        value, quantity = groups[0] if groups else (0.0, 0.0)
+        if not quantity or float_is_zero(
+            quantity, precision_rounding=self.product_id.uom_id.rounding
+        ):
             return None
-        value, quantity = groups[0]
-        if float_is_zero(quantity, precision_rounding=self.product_id.uom_id.rounding):
-            return None
-        currency = self.company_id.currency_id
-        return currency.round(value) / quantity
+        return self.company_id.currency_id.round(value) / quantity
 
     # cred ca este mai bine sa generam doua svl - o intrare si o iesire
     def _create_internal_transfer_svl(self, forced_quantity=None):

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -142,13 +142,13 @@ class StockValuationLayer(models.Model):
         """
         for svl in self:
             currency = svl.company_id.currency_id
-            vals = {
-                "unit_cost": unit_cost,
-                "value": currency.round(svl.quantity * unit_cost),
-            }
-            if svl.remaining_qty:
-                vals["remaining_value"] = currency.round(svl.remaining_qty * unit_cost)
-            svl.write(vals)
+            svl.write(
+                {
+                    "unit_cost": unit_cost,
+                    "value": currency.round(svl.quantity * unit_cost),
+                    "remaining_value": currency.round(svl.remaining_qty * unit_cost),
+                }
+            )
 
     # hook method for reception in progress
     def _l10n_ro_can_use_invoice_line_account(self, account):

--- a/l10n_ro_stock_account_tracking/models/stock_move.py
+++ b/l10n_ro_stock_account_tracking/models/stock_move.py
@@ -329,11 +329,6 @@ class StockMove(models.Model):
                 )
                 for svl_vals in svl_vals_list:
                     svl_vals.update(move._prepare_common_svl_vals())
-                    if unit_cost is not None:
-                        svl_vals["unit_cost"] = unit_cost
-                        svl_vals["value"] = move.company_id.currency_id.round(
-                            svl_vals["quantity"] * unit_cost
-                        )
                     if forced_quantity:
                         svl_vals["description"] = (
                             f"Correction of {move.picking_id.name or move.name}"
@@ -341,21 +336,26 @@ class StockMove(models.Model):
                         )
                     svl_vals["description"] += svl_vals.pop("rounding_adjustment", "")
                     svl_vals["l10n_ro_stock_move_line_id"] = valued_move_line.id
-                    svls |= self._l10n_ro_create_track_svl([svl_vals])
+                    out_svl = self._l10n_ro_create_track_svl([svl_vals])
+                    if unit_cost is not None:
+                        out_svl._l10n_ro_set_unit_cost(unit_cost)
+                    svls |= out_svl
 
+                    # The incoming leg mirrors the outgoing one: a transfer
+                    # neither creates nor destroys value.
                     new_svl_vals = svl_vals.copy()
                     new_svl_vals.update(
                         {
-                            "quantity": abs(svl_vals.get("quantity", 0)),
-                            "remaining_qty": abs(svl_vals.get("quantity", 0)),
-                            "unit_cost": abs(svl_vals.get("unit_cost", 0)),
-                            "value": abs(svl_vals.get("value", 0)),
-                            "remaining_value": abs(svl_vals.get("value", 0)),
+                            "quantity": abs(out_svl.quantity),
+                            "remaining_qty": abs(out_svl.quantity),
+                            "unit_cost": abs(out_svl.unit_cost),
+                            "value": abs(out_svl.value),
+                            "remaining_value": abs(out_svl.value),
                             "l10n_ro_tracking": [
                                 (
-                                    svls[-1].id,
-                                    abs(svl_vals.get("quantity", 0)),
-                                    abs(svl_vals.get("value", 0)),
+                                    out_svl.id,
+                                    abs(out_svl.quantity),
+                                    abs(out_svl.value),
                                 )
                             ],
                         }


### PR DESCRIPTION
Follow-up to #1557, which is already merged. That PR fixed the internal transfer valuation, but it had to be fixed **twice** — once in `l10n_ro_stock_account` and once in `l10n_ro_stock_account_tracking`, because the latter overrides `_create_internal_transfer_svl` in full, for every cost method and not only for FIFO. The first push of #1557 only patched the base module and CI caught it. That is the duplication this PR removes.

## What changes

- The tracking module was adjusting the layer values inline while `l10n_ro_stock_account` used `_l10n_ro_set_unit_cost`. Both now go through the shared helper, so the rule lives in one place.
- `_l10n_ro_get_source_account_unit_cost` no longer assumes `_read_group` returns a usable row. An account holding nothing for the product sums to `None` over an empty set, which would have raised inside `float_is_zero`.
- `_l10n_ro_set_unit_cost` now always keeps `remaining_value` in step with the quantity it revalues, instead of leaving a stale amount behind when `remaining_qty` is zero.

No behaviour change is intended for either cost method: FIFO still consumes the real layers, and both legs of an internal transfer are still valued at the cost the source valuation account holds.

## Tests

`l10n_ro_stock_account` + `l10n_ro_stock_account_tracking` run 66/66 green locally on top of the current `18.0`, with the tracking module installed (which is the configuration where the base implementation is shadowed).