### PR TITLE
[FIX] l10n_ro_message_spv: mark matched SPV documents as validated, not sent

### DIFF
--- a/l10n_ro_message_spv/README.rst
+++ b/l10n_ro_message_spv/README.rst
@@ -223,6 +223,25 @@ Configuration
 Changelog
 =========
 
+**19.0.2.9.1 (2026-08-13)**
+
+- Matching an SPV message to an invoice no longer leaves the invoice in
+  the ``invoice_sent`` E-Factura state. The EDI document created at
+  match time is now ``invoice_validated``, a terminal state: the
+  document is already in the SPV (the message proves it) and this
+  instance never uploaded it, so there is nothing to fetch a status for.
+  With ``invoice_sent``, the fetch-status cron queried ANAF with an
+  empty ``l10n_ro_edi_index``, failed on every run, logged the failure
+  in the chatter and re-triggered itself every 2 minutes for as long as
+  such an invoice existed — an endless loop. This shows up on
+  self-billed invoices a customer issues in the supplier's name, which
+  can only be matched by hand. Re-sending to the SPV stays blocked, as
+  before.
+- Invoices this instance did upload are unaffected: they already carry
+  an EDI document with the upload index, so their normal
+  ``invoice_sent`` -> ``invoice_validated`` flow and signature retrieval
+  are untouched.
+
 **19.0.2.7.0 (2026-07-28)**
 
 - The product can now be corrected on a bill line imported from SPV

--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "19.0.2.9.0",
+    "version": "19.0.2.9.1",
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -479,27 +479,35 @@ class MessageSPV(models.Model):
                     {"res_id": message.invoice_id.id, "res_model": "account.move"}
                 )
 
-                if "out" in message.message_type:
-                    if not message.invoice_id.l10n_ro_edi_document_ids:
-                        self.env["l10n_ro_edi.document"].create(
-                            {
-                                "invoice_id": message.invoice_id.id,
-                                "state": "invoice_sent",
-                            }
-                        )
                 if not message.invoice_id.l10n_ro_edi_document_ids:
-                    if message.message_type in ("in_invoice", "in_receipt"):
-                        # Facturile primite se marchează invoice_validated, nu
-                        # invoice_sent. Core-ul l10n_ro_edi deduplică facturile
-                        # primite dupa l10n_ro_edi_state == 'invoice_validated';
-                        # cum starea e calculata din primul document EDI, daca
-                        # punem invoice_sent factura importata nu mai e gasita la
-                        # dedup, iar cronul de import o recreeaza (duplicat).
-                        edi_state = "invoice_validated"
-                    elif message.message_type == "error":
+                    if message.message_type == "error":
                         edi_state = "invoice_refused"
                     else:
-                        edi_state = "invoice_sent"
+                        # The document is already in the SPV — the very
+                        # existence of the message proves it — and the invoice
+                        # carries no EDI document, so this instance never
+                        # uploaded anything. The correct state is the terminal
+                        # one, invoice_validated:
+                        #
+                        # - for received bills, l10n_ro_edi core deduplicates on
+                        #   l10n_ro_edi_state == 'invoice_validated'; with
+                        #   invoice_sent the imported bill is no longer found at
+                        #   dedup time and the import cron recreates it
+                        #   (duplicate bills);
+                        # - for our own invoices (including self-billed ones the
+                        #   customer issued in our name), invoice_sent would
+                        #   queue the document for the fetch-status cron, which
+                        #   queries ANAF with l10n_ro_edi_index — empty, since we
+                        #   did not upload it. The fetch fails on every run, logs
+                        #   in the chatter, and re-triggers itself every 2
+                        #   minutes for as long as an invoice_sent invoice
+                        #   exists, so the loop never ends.
+                        #
+                        # Invoices this instance did upload already have an EDI
+                        # document holding the index, so they never reach this
+                        # branch: their normal sent -> validated flow (and the
+                        # signature retrieval) is untouched.
+                        edi_state = "invoice_validated"
 
                     self.env["l10n_ro_edi.document"].create(
                         {

--- a/l10n_ro_message_spv/readme/HISTORY.md
+++ b/l10n_ro_message_spv/readme/HISTORY.md
@@ -1,3 +1,21 @@
+**19.0.2.9.1 (2026-08-13)**
+
+- Matching an SPV message to an invoice no longer leaves the invoice in
+  the `invoice_sent` E-Factura state. The EDI document created at match
+  time is now `invoice_validated`, a terminal state: the document is
+  already in the SPV (the message proves it) and this instance never
+  uploaded it, so there is nothing to fetch a status for. With
+  `invoice_sent`, the fetch-status cron queried ANAF with an empty
+  `l10n_ro_edi_index`, failed on every run, logged the failure in the
+  chatter and re-triggered itself every 2 minutes for as long as such an
+  invoice existed — an endless loop. This shows up on self-billed
+  invoices a customer issues in the supplier's name, which can only be
+  matched by hand. Re-sending to the SPV stays blocked, as before.
+- Invoices this instance did upload are unaffected: they already carry an
+  EDI document with the upload index, so their normal
+  `invoice_sent` -> `invoice_validated` flow and signature retrieval are
+  untouched.
+
 **19.0.2.7.0 (2026-07-28)**
 
 - The product can now be corrected on a bill line imported from SPV

--- a/l10n_ro_message_spv/static/description/index.html
+++ b/l10n_ro_message_spv/static/description/index.html
@@ -599,6 +599,25 @@ XML-ul a fost validat de sistemul ANAF.</li>
 </div>
 <div class="section" id="changelog">
 <h4><a class="toc-backref" href="#toc-entry-2">Changelog</a></h4>
+<p><strong>19.0.2.9.1 (2026-08-13)</strong></p>
+<ul class="simple">
+<li>Matching an SPV message to an invoice no longer leaves the invoice in
+the <tt class="docutils literal">invoice_sent</tt> E-Factura state. The EDI document created at
+match time is now <tt class="docutils literal">invoice_validated</tt>, a terminal state: the
+document is already in the SPV (the message proves it) and this
+instance never uploaded it, so there is nothing to fetch a status for.
+With <tt class="docutils literal">invoice_sent</tt>, the fetch-status cron queried ANAF with an
+empty <tt class="docutils literal">l10n_ro_edi_index</tt>, failed on every run, logged the failure
+in the chatter and re-triggered itself every 2 minutes for as long as
+such an invoice existed — an endless loop. This shows up on
+self-billed invoices a customer issues in the supplier’s name, which
+can only be matched by hand. Re-sending to the SPV stays blocked, as
+before.</li>
+<li>Invoices this instance did upload are unaffected: they already carry
+an EDI document with the upload index, so their normal
+<tt class="docutils literal">invoice_sent</tt> -&gt; <tt class="docutils literal">invoice_validated</tt> flow and signature retrieval
+are untouched.</li>
+</ul>
 <p><strong>19.0.2.7.0 (2026-07-28)</strong></p>
 <ul class="simple">
 <li>The product can now be corrected on a bill line imported from SPV

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -845,6 +845,76 @@ class TestMessageSPV(TestMessageSPV):
         self.assertEqual(invoice.l10n_ro_edi_document_ids[0].state, "invoice_validated")
         self.assertEqual(invoice.l10n_ro_edi_state, "invoice_validated")
 
+    def test_out_message_edi_state_validated(self):
+        """An out message matched by hand (typically a self-billed invoice the
+        customer issued in our name) must get an invoice_validated EDI
+        document, not invoice_sent.
+
+        With invoice_sent the fetch-status cron queries ANAF using
+        l10n_ro_edi_index — empty, because the upload never left this
+        instance — fails on every run and re-triggers itself every 2 minutes
+        for as long as an invoice_sent invoice exists, so it never stops."""
+        refund = self.env["account.move"].create(
+            {
+                "move_type": "out_refund",
+                "partner_id": self.vendor.id,
+                "ref": "00027547122026",
+            }
+        )
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_OUT_SELF",
+                "request_id": "REQ_OUT_SELF",
+                "cif": "123",
+                "message_type": "out_invoice",
+                "partner_id": self.vendor.id,
+                "invoice_id": refund.id,
+            }
+        )
+        self.assertFalse(refund.l10n_ro_edi_document_ids)
+
+        message_spv.get_data_from_invoice()
+
+        self.assertEqual(len(refund.l10n_ro_edi_document_ids), 1)
+        self.assertEqual(refund.l10n_ro_edi_document_ids[0].state, "invoice_validated")
+        self.assertEqual(refund.l10n_ro_edi_state, "invoice_validated")
+        # The state is no longer the one the fetch-status cron queries, and
+        # re-sending stays blocked: _is_ro_edi_applicable requires an empty
+        # l10n_ro_edi_state or invoice_refused.
+        self.assertNotIn(
+            refund.l10n_ro_edi_state, (False, "invoice_sent", "invoice_refused")
+        )
+
+    def test_out_message_keeps_existing_edi_document(self):
+        """Invoices uploaded by this very instance already have an EDI document
+        holding the index: matching must not touch their state, so the normal
+        invoice_sent -> invoice_validated flow (and the signature retrieval)
+        stays unchanged."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.vendor.id,
+            }
+        )
+        existing = self.env["l10n_ro_edi.document"].create(
+            {"invoice_id": invoice.id, "state": "invoice_sent"}
+        )
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_OUT_OWN",
+                "request_id": "REQ_OUT_OWN",
+                "cif": "123",
+                "message_type": "out_invoice",
+                "partner_id": self.vendor.id,
+                "invoice_id": invoice.id,
+            }
+        )
+
+        message_spv.get_data_from_invoice()
+
+        self.assertEqual(invoice.l10n_ro_edi_document_ids, existing)
+        self.assertEqual(invoice.l10n_ro_edi_state, "invoice_sent")
+
     def test_onchange_invoice_id(self):
         """Testează _onchange_invoice_id pentru diverse tipuri de facturi"""
         invoice = self.env["account.move"].create(


### PR DESCRIPTION
## The problem

Matching an SPV message to an invoice created the EDI document in the `invoice_sent` state. That state is not terminal: `_cron_l10n_ro_edi_fetch_status` picks up every `out_invoice`/`out_refund` in it and queries ANAF using `l10n_ro_edi_index`, which is empty because the upload never left this instance (the fetch reads the index off the invoice, not `key_loading` off the document).

The result: the fetch fails on every run, logs the failure in the chatter, and — since the cron re-triggers itself for as long as at least one `invoice_sent` invoice exists in the window — it reschedules itself every 2 minutes indefinitely. The loop never ends.

This surfaces on **self-billed invoices**, where the customer issues the invoice in the supplier name and reports it to ANAF itself (`InvoiceTypeCode 389`). The supplier can only record such a document by hand and match it to the SPV message, so it stays in `invoice_sent` forever.

## The fix

Create the document as `invoice_validated` instead. The document is already in the SPV — the existence of the message proves it — so there is no status left to fetch, and re-sending stays blocked exactly as before: `_is_ro_edi_applicable` requires an empty state, and the auto-send flow filters on it too.

Invoices this instance did upload are **unaffected**: they already carry an EDI document holding the upload index, so they never reach this branch, and their normal `invoice_sent` -> `invoice_validated` flow, including the signature retrieval, is untouched. The branch only ever runs for invoices with no EDI document at all — by definition the ones that were never sent from this Odoo.

As a side effect, the two overlapping branches that created the document (one for `out_*`, one for everything else) are now a single one.

## Tests

Two new tests: `test_out_message_edi_state_validated` (an out message matched by hand ends up `invoice_validated`) and `test_out_message_keeps_existing_edi_document` (an invoice with its own EDI document keeps its state). The first one fails on the unfixed code with `AssertionError: 'invoice_sent' != 'invoice_validated'`.

The module suite passes on both series: **19.0 — 40 tests, 0 failures** and **18.0 — 31 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)