### PR TITLE
[19.0][FIX] l10n_ro_stock_account: value internal transfers at the source warehouse cost

### DIFF
--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -124,6 +124,35 @@ Performance notes
 Changelog
 =========
 
+19.0.1.3.0
+----------
+
+- Value an internal transfer at the cost the source warehouse actually
+  holds for the product, instead of the product's global average. Both
+  legs of the transfer entry are built from a single
+  ``stock.move.value``, so they can never diverge on this series - what
+  was wrong is the amount itself: a transfer between two warehouses took
+  out of the source warehouse the average computed over *all*
+  warehouses. When that average was higher than what the source
+  warehouse held, the warehouse was left with value and no quantity to
+  carry it (and the other way round when it was lower), which is what
+  the storage sheet shows per warehouse. The accounting stayed balanced
+  throughout, only the per-warehouse valuation was off.
+- The new ``_l10n_ro_get_source_account_unit_cost`` rebuilds that cost
+  from the done moves in and out of the locations sharing the source
+  valuation account. It is plugged into ``_get_value_from_std_price``,
+  the last step of the standard valuation chain, so a value coming from
+  a bill, a quotation, a return or a landed cost keeps priority exactly
+  as before; only the fallback to the product's global cost is replaced.
+  FIFO and lot valued products are left alone - there the cost already
+  comes from the layers or from the lot - and so are source locations
+  without a valuation account of their own, where there is no
+  per-warehouse cost to follow.
+- Same defect as the one fixed on 18.0 by
+  ``_l10n_ro_get_source_account_unit_cost`` in 18.0.1.29.0, but with a
+  different mechanism: on this series the valuation layer is gone and
+  the value lives on the move.
+
 19.0.1.1.1
 ----------
 

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -301,6 +301,103 @@ class StockMove(models.Model):
             move.value = move.sudo()._get_value()
         return res
 
+    def _l10n_ro_get_source_account_unit_cost(self):
+        """Unit cost the source warehouse account actually holds for the product.
+
+        An internal transfer must move the value the source warehouse owns for
+        the goods, not the average taken over every warehouse. The balance is
+        rebuilt from the done moves in and out of the locations sharing the
+        source valuation account, which is what the storage sheet reports per
+        warehouse.
+
+        Returns ``None`` when the cost cannot be established, in which case the
+        caller keeps the standard behaviour. This is notably the case when the
+        source location has no valuation account of its own: source and
+        destination then share the product account and the global cost is
+        already the right one.
+        """
+        self.ensure_one()
+        src_account = self.location_id.with_company(
+            self.company_id
+        ).l10n_ro_property_stock_valuation_account_id
+        if not src_account:
+            return None
+        locations = (
+            self.env["stock.location"]
+            .sudo()
+            .with_company(self.company_id)
+            .search(
+                [
+                    ("usage", "=", "internal"),
+                    ("company_id", "in", [False, self.company_id.id]),
+                    (
+                        "l10n_ro_property_stock_valuation_account_id",
+                        "=",
+                        src_account.id,
+                    ),
+                ]
+            )
+        )
+        if not locations:
+            return None
+        domain = [
+            ("product_id", "=", self.product_id.id),
+            ("state", "=", "done"),
+            ("company_id", "=", self.company_id.id),
+            ("id", "!=", self.id),
+        ]
+        move_obj = self.env["stock.move"].sudo()
+        value = quantity = 0.0
+        # Moves landing in the warehouse add value, moves leaving it remove
+        # value; a move inside the warehouse appears on both sides and cancels
+        # out, as it should.
+        for sign, location_field in ((1, "location_dest_id"), (-1, "location_id")):
+            groups = move_obj._read_group(
+                domain + [(location_field, "in", locations.ids)],
+                aggregates=["value:sum", "product_qty:sum"],
+            )
+            # _read_group returns an empty list when nothing matches.
+            group_value, group_quantity = groups[0] if groups else (0.0, 0.0)
+            value += sign * (group_value or 0.0)
+            quantity += sign * (group_quantity or 0.0)
+        if quantity <= 0 or self.product_id.uom_id.is_zero(quantity):
+            return None
+        return value / quantity
+
+    def _get_value_from_std_price(self, quantity, std_price=False, at_date=None):
+        """Value an internal transfer at the cost held by the source warehouse.
+
+        Only the last step of ``_get_value_data`` is replaced, so a value coming
+        from a bill, a quotation, a return or a landed cost keeps priority
+        exactly as in the standard flow; the override kicks in only where the
+        standard flow would fall back to the product's global cost.
+
+        FIFO and lot valued products are left alone: there the cost already
+        comes from the layers or from the lot, not from a global average.
+        """
+        if (
+            not std_price
+            and not at_date
+            and self.is_l10n_ro_record
+            and self.l10n_ro_move_type == "internal_transfer"
+            and self.product_id.cost_method != "fifo"
+            and not self.product_id.lot_valuated
+        ):
+            unit_cost = self.sudo()._l10n_ro_get_source_account_unit_cost()
+            if unit_cost is not None:
+                return {
+                    "value": unit_cost * quantity,
+                    "quantity": quantity,
+                    "description": self.env._(
+                        "%(quantity)s %(uom)s at the cost of the source warehouse",
+                        quantity=quantity,
+                        uom=self.product_id.uom_id.name,
+                    ),
+                }
+        return super()._get_value_from_std_price(
+            quantity, std_price=std_price, at_date=at_date
+        )
+
     def _get_valued_qty(self, lot=None):
         self.ensure_one()
         if self.is_l10n_ro_record and self.l10n_ro_move_type == "internal_transfer":

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,3 +1,28 @@
+## 19.0.1.3.0
+
+- Value an internal transfer at the cost the source warehouse actually holds
+  for the product, instead of the product's global average. Both legs of the
+  transfer entry are built from a single `stock.move.value`, so they can never
+  diverge on this series - what was wrong is the amount itself: a transfer
+  between two warehouses took out of the source warehouse the average computed
+  over *all* warehouses. When that average was higher than what the source
+  warehouse held, the warehouse was left with value and no quantity to carry
+  it (and the other way round when it was lower), which is what the storage
+  sheet shows per warehouse. The accounting stayed balanced throughout, only
+  the per-warehouse valuation was off.
+- The new `_l10n_ro_get_source_account_unit_cost` rebuilds that cost from the
+  done moves in and out of the locations sharing the source valuation account.
+  It is plugged into `_get_value_from_std_price`, the last step of the standard
+  valuation chain, so a value coming from a bill, a quotation, a return or a
+  landed cost keeps priority exactly as before; only the fallback to the
+  product's global cost is replaced. FIFO and lot valued products are left
+  alone - there the cost already comes from the layers or from the lot - and so
+  are source locations without a valuation account of their own, where there is
+  no per-warehouse cost to follow.
+- Same defect as the one fixed on 18.0 by `_l10n_ro_get_source_account_unit_cost`
+  in 18.0.1.29.0, but with a different mechanism: on this series the valuation
+  layer is gone and the value lives on the move.
+
 ## 19.0.1.1.1
 
 - Fix silent over-delivery in `stock_move._split_for_fifo_assignment`: it

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -464,6 +464,36 @@ Inventory Valuation reports drop from O(N) queries to O(distinct
 </div>
 </div>
 <div class="section" id="section-1">
+<h2>19.0.1.3.0</h2>
+<ul class="simple">
+<li>Value an internal transfer at the cost the source warehouse actually
+holds for the product, instead of the product’s global average. Both
+legs of the transfer entry are built from a single
+<tt class="docutils literal">stock.move.value</tt>, so they can never diverge on this series - what
+was wrong is the amount itself: a transfer between two warehouses took
+out of the source warehouse the average computed over <em>all</em>
+warehouses. When that average was higher than what the source
+warehouse held, the warehouse was left with value and no quantity to
+carry it (and the other way round when it was lower), which is what
+the storage sheet shows per warehouse. The accounting stayed balanced
+throughout, only the per-warehouse valuation was off.</li>
+<li>The new <tt class="docutils literal">_l10n_ro_get_source_account_unit_cost</tt> rebuilds that cost
+from the done moves in and out of the locations sharing the source
+valuation account. It is plugged into <tt class="docutils literal">_get_value_from_std_price</tt>,
+the last step of the standard valuation chain, so a value coming from
+a bill, a quotation, a return or a landed cost keeps priority exactly
+as before; only the fallback to the product’s global cost is replaced.
+FIFO and lot valued products are left alone - there the cost already
+comes from the layers or from the lot - and so are source locations
+without a valuation account of their own, where there is no
+per-warehouse cost to follow.</li>
+<li>Same defect as the one fixed on 18.0 by
+<tt class="docutils literal">_l10n_ro_get_source_account_unit_cost</tt> in 18.0.1.29.0, but with a
+different mechanism: on this series the valuation layer is gone and
+the value lives on the move.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h2>19.0.1.1.1</h2>
 <ul class="simple">
 <li>Fix silent over-delivery in <tt class="docutils literal">stock_move._split_for_fifo_assignment</tt>:
@@ -488,7 +518,7 @@ instead of silently completing the transfer if the amount accounted
 for by the split still doesn’t match.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h2>19.0.1.0.0</h2>
 <ul class="simple">
 <li>Recognise the exchange rate difference on the 408 pivot (<em>Furnizori -
@@ -521,7 +551,7 @@ difference, whose liability arises at the invoice date - is taken at
 the invoice rate.</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h2>19.0.0.26.1</h2>
 <ul class="simple">
 <li>Expose the <tt class="docutils literal">stock.move.l10n_ro_move_type</tt> selection as the module
@@ -530,7 +560,7 @@ duplicating the list. Up to 18.0 the same list was available as
 <tt class="docutils literal">VALUED_TYPE</tt> on <tt class="docutils literal">stock.valuation.layer</tt>. No functional change.</li>
 </ul>
 </div>
-<div class="section" id="section-4">
+<div class="section" id="section-5">
 <h2>19.0.0.25.1</h2>
 <ul class="simple">
 <li>Fix <tt class="docutils literal">IndexError: list index out of range</tt> in
@@ -545,7 +575,7 @@ the quantities are compared with the UoM rounding instead of raw
 floats.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
+<div class="section" id="section-6">
 <h2>19.0.0.19.1</h2>
 <ul class="simple">
 <li>Fix

--- a/l10n_ro_stock_account/tests/__init__.py
+++ b/l10n_ro_stock_account/tests/__init__.py
@@ -6,5 +6,6 @@ from . import test_ro_stock_fifo_zero_qty
 from . import test_ro_stock_fifo_partial_delivery
 from . import test_ro_stock_avg
 from . import test_stock_fifo_internal_transfer
+from . import test_avg_internal_transfer
 from . import test_stock_location
 from . import test_notice_currency

--- a/l10n_ro_stock_account/tests/test_avg_internal_transfer.py
+++ b/l10n_ro_stock_account/tests/test_avg_internal_transfer.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2026 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tests import tagged
+
+from .common import TestROStockCommon
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install")
+class TestAVGInternalTransfer(TestROStockCommon):
+    """An internal transfer must move the value of the source warehouse.
+
+    The product is received at two different prices in two warehouses with
+    different valuation accounts, so that the global average matches neither
+    of them. Valuing the transfer at the global average would leave value
+    behind in the source warehouse without any quantity to carry it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Warehouse 2 already has its own valuation account (371001); give
+        # warehouse 3 one too, so both ends of the transfer are identifiable
+        # warehouses rather than the product's default account.
+        cls.account_valuation_wh3 = cls.env.company.account_stock_valuation_id.copy(
+            {"code": "371003"}
+        )
+        cls.location2.write(
+            {
+                "l10n_ro_property_stock_valuation_account_id": (
+                    cls.account_valuation_wh3.id
+                )
+            }
+        )
+
+    def _receive(self, location, qty, price):
+        self.test_case(
+            {
+                "steps": [
+                    {
+                        "type": "purchase",
+                        "currency_id": self.env.company.currency_id,
+                        "partner_id": self.supplier_1,
+                        "product_id": self.product_avg,
+                        "location": location,
+                        "step": 1,
+                        "qty": qty,
+                        "stock_qty": qty,
+                        "inv_qty": qty,
+                        "price": price,
+                        "inv_price": price,
+                    }
+                ]
+            }
+        )
+
+    def _transfer(self, location_src, location_dest, qty):
+        move = self.env["stock.move"].create(
+            {
+                "company_id": self.env.company.id,
+                "location_id": location_src.id,
+                "location_dest_id": location_dest.id,
+                "product_id": self.product_avg.id,
+                "product_uom": self.product_avg.uom_id.id,
+                "product_uom_qty": qty,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        move._set_quantity_done(qty)
+        move.picked = True
+        move._action_done()
+        return move
+
+    def test_internal_transfer_valued_at_source_warehouse_cost(self):
+        self._receive(self.location1, 10.0, 40.0)
+        self._receive(self.location2, 10.0, 60.0)
+
+        # The global average is 50, which is the cost of neither warehouse.
+        self.assertAlmostEqual(self.product_avg.standard_price, 50.0)
+
+        move = self._transfer(self.location1, self.location2, 10.0)
+
+        self.assertEqual(move.l10n_ro_move_type, "internal_transfer")
+        # Without the fix the move is valued at the global average, 500.
+        self.assertAlmostEqual(move.value, 400.0)
+
+        # Both legs of the entry are built from that single value, so the
+        # source warehouse is emptied of exactly what it held.
+        account_move = move.account_move_id
+        self.assertTrue(account_move)
+        source_lines = account_move.line_ids.filtered(
+            lambda line: line.account_id
+            == self.location1.l10n_ro_property_stock_valuation_account_id
+        )
+        self.assertAlmostEqual(sum(source_lines.mapped("balance")), -400.0)
+
+    def test_internal_transfer_without_source_account_keeps_standard_cost(self):
+        """No valuation account on the source location: nothing changes.
+
+        Source and destination then share the product's account, so there is
+        no per-warehouse cost to follow and the standard behaviour applies.
+        """
+        self._receive(self.location, 10.0, 40.0)
+        self._receive(self.location2, 10.0, 60.0)
+
+        self.assertAlmostEqual(self.product_avg.standard_price, 50.0)
+        self.assertFalse(
+            self.location.l10n_ro_property_stock_valuation_account_id,
+        )
+
+        move = self._transfer(self.location, self.location2, 10.0)
+
+        self.assertEqual(move.l10n_ro_move_type, "internal_transfer")
+        self.assertAlmostEqual(move.value, 500.0)


### PR DESCRIPTION
On 19.0 an internal transfer takes out of the source warehouse the product's
**global** average instead of the cost that warehouse actually holds.

Both legs of the transfer entry are built from a single `stock.move.value`
(`_set_value` → `_get_value`, then `_get_l10n_ro_move_type_account_list` pairs
them through the transfer account), so they can never diverge and the
accounting stays balanced. What is wrong is the amount itself: when the global
average is higher than what the source warehouse held, the warehouse is left
with value and no quantity to carry it — and the other way round when it is
lower. This is what the storage sheet shows per warehouse.

For an internal transfer the first steps of the standard valuation chain are
inert by construction (no invoice line, no quotation line, no origin move), so
the value always falls through to the last step, the product cost.

### The fix

`_l10n_ro_get_source_account_unit_cost()` rebuilds the cost the source
warehouse holds: the value balance over the quantity balance, from the done
moves in and out of the locations sharing the source valuation account — the
same balance the storage sheet reports per warehouse.

It is plugged into `_get_value_from_std_price`, i.e. **only the last step** of
`_get_value_data`. A value coming from a bill, a quotation, a return or a
landed cost keeps its priority exactly as before; only the fallback to the
product's global cost is replaced. No second valuation path competing with the
existing order.

Guards, to keep the blast radius on the case at hand — the method returns
`None` and the standard behaviour applies when:

- the product is FIFO (the cost comes from the layers) or lot valued;
- a forced standard price or an `at_date` is requested;
- the source location has no valuation account of its own — source and
  destination then share the product account, there is no per-warehouse cost
  to follow, and the global cost is already the right one;
- `_read_group` finds nothing, or the resulting quantity is zero or negative.

### Relation to 18.0

Same defect and same method name as
https://github.com/OCA/l10n-romania/pull/1557 (18.0.1.29.0), different
mechanism: on this series the valuation layer is gone and the value lives on
the move, so the implementation had to be rewritten rather than ported. Keeping
both in the common module means a database migrating 18.0 → 19.0 does not lose
the correction.

Unlike 18.0, `l10n_ro_stock_account_tracking` does **not** shadow the valuation
on 19.0 (it only carries two FIFO split helpers), so there is a single
implementation to fix here.

### Tests

`tests/test_avg_internal_transfer.py`, with an average-cost product received at
40 in one warehouse and at 60 in another, so the global average of 50 matches
neither:

- the transfer follows the source warehouse cost — **fails without the fix**
  with `AssertionError: 500.0 != 400.0`, passes with it, and the source account
  leg of the entry is checked to be exactly -400;
- control test: with no valuation account on the source location the value
  stays the standard one (500), i.e. the fix does not engage where there is
  nothing to correct.

43/43 green locally with `l10n_ro_stock_account`,
`l10n_ro_stock_account_tracking`, `l10n_ro_stock_account_landed_cost` and
`l10n_ro_stock_account_date` installed together.
