### PR TITLE
[19.0][FIX] l10n_ro_stock_account: keep the standard valuation on a negative source warehouse cost

### DIFF
--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -124,6 +124,18 @@ Performance notes
 Changelog
 =========
 
+19.0.1.5.0
+----------
+
+- Keep the standard valuation for an internal transfer whose source
+  warehouse holds a negative balance with goods still on hand, a state
+  left behind by earlier mis-valuations. The per-warehouse cost is the
+  balance over the quantity, so such a warehouse yields a negative cost;
+  valuing the move at it made the move value negative, which ran the
+  whole entry backwards: the source warehouse came out debited instead
+  of credited, so the transfer deepened its negative balance instead of
+  relieving it.
+
 19.0.1.3.0
 ----------
 

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.1.4.0",
+    "version": "19.0.1.5.0",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -362,7 +362,17 @@ class StockMove(models.Model):
             quantity += sign * (group_quantity or 0.0)
         if quantity <= 0 or self.product_id.uom_id.is_zero(quantity):
             return None
-        return value / quantity
+        unit_cost = value / quantity
+        if unit_cost <= 0:
+            # A warehouse left with a negative balance by earlier
+            # mis-valuations gives a negative cost, which is not a cost the
+            # goods can be taken out at: the move would be valued negatively,
+            # which runs its whole entry backwards - the source warehouse
+            # debited instead of credited - so the transfer would deepen the
+            # negative balance instead of relieving it. Keep the standard
+            # valuation and let the existing imbalance be corrected on its own.
+            return None
+        return unit_cost
 
     def _get_value_from_std_price(self, quantity, std_price=False, at_date=None):
         """Value an internal transfer at the cost held by the source warehouse.

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,3 +1,13 @@
+## 19.0.1.5.0
+
+- Keep the standard valuation for an internal transfer whose source warehouse
+  holds a negative balance with goods still on hand, a state left behind by
+  earlier mis-valuations. The per-warehouse cost is the balance over the
+  quantity, so such a warehouse yields a negative cost; valuing the move at it
+  made the move value negative, which ran the whole entry backwards: the
+  source warehouse came out debited instead of credited, so the transfer
+  deepened its negative balance instead of relieving it.
+
 ## 19.0.1.3.0
 
 - Value an internal transfer at the cost the source warehouse actually holds

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -464,6 +464,19 @@ Inventory Valuation reports drop from O(N) queries to O(distinct
 </div>
 </div>
 <div class="section" id="section-1">
+<h2>19.0.1.5.0</h2>
+<ul class="simple">
+<li>Keep the standard valuation for an internal transfer whose source
+warehouse holds a negative balance with goods still on hand, a state
+left behind by earlier mis-valuations. The per-warehouse cost is the
+balance over the quantity, so such a warehouse yields a negative cost;
+valuing the move at it made the move value negative, which ran the
+whole entry backwards: the source warehouse came out debited instead
+of credited, so the transfer deepened its negative balance instead of
+relieving it.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h2>19.0.1.3.0</h2>
 <ul class="simple">
 <li>Value an internal transfer at the cost the source warehouse actually
@@ -493,7 +506,7 @@ different mechanism: on this series the valuation layer is gone and
 the value lives on the move.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h2>19.0.1.1.1</h2>
 <ul class="simple">
 <li>Fix silent over-delivery in <tt class="docutils literal">stock_move._split_for_fifo_assignment</tt>:
@@ -518,7 +531,7 @@ instead of silently completing the transfer if the amount accounted
 for by the split still doesn’t match.</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h2>19.0.1.0.0</h2>
 <ul class="simple">
 <li>Recognise the exchange rate difference on the 408 pivot (<em>Furnizori -
@@ -551,7 +564,7 @@ difference, whose liability arises at the invoice date - is taken at
 the invoice rate.</li>
 </ul>
 </div>
-<div class="section" id="section-4">
+<div class="section" id="section-5">
 <h2>19.0.0.26.1</h2>
 <ul class="simple">
 <li>Expose the <tt class="docutils literal">stock.move.l10n_ro_move_type</tt> selection as the module
@@ -560,7 +573,7 @@ duplicating the list. Up to 18.0 the same list was available as
 <tt class="docutils literal">VALUED_TYPE</tt> on <tt class="docutils literal">stock.valuation.layer</tt>. No functional change.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
+<div class="section" id="section-6">
 <h2>19.0.0.25.1</h2>
 <ul class="simple">
 <li>Fix <tt class="docutils literal">IndexError: list index out of range</tt> in
@@ -575,7 +588,7 @@ the quantities are compared with the UoM rounding instead of raw
 floats.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
+<div class="section" id="section-7">
 <h2>19.0.0.19.1</h2>
 <ul class="simple">
 <li>Fix

--- a/l10n_ro_stock_account/tests/test_avg_internal_transfer.py
+++ b/l10n_ro_stock_account/tests/test_avg_internal_transfer.py
@@ -117,3 +117,54 @@ class TestAVGInternalTransfer(TestROStockCommon):
 
         self.assertEqual(move.l10n_ro_move_type, "internal_transfer")
         self.assertAlmostEqual(move.value, 500.0)
+
+    def test_internal_transfer_out_of_a_negative_warehouse(self):
+        """A warehouse holding a negative balance falls back to the standard.
+
+        The per-warehouse cost is the balance over the quantity, so a warehouse
+        left by earlier mis-valuations with a negative balance and goods still
+        on hand yields a negative cost. Valuing the move at it would make the
+        move value negative, which runs the whole entry backwards: the source
+        warehouse comes out debited instead of credited, so the transfer
+        deepens its negative balance instead of relieving it. There is no cost
+        the goods can honestly be taken out at here, so the standard valuation
+        is kept.
+        """
+        self._receive(self.location1, 10.0, 40.0)
+        self._receive(self.location2, 10.0, 60.0)
+        self.assertAlmostEqual(self.product_avg.standard_price, 50.0)
+
+        # Warehouse 1 still holds the 10 pieces, but an earlier mis-valuation
+        # left its balance at -100, i.e. a cost of -10 a piece.
+        receipt_move = self.env["stock.move"].search(
+            [
+                ("product_id", "=", self.product_avg.id),
+                ("location_dest_id", "=", self.location1.id),
+                ("state", "=", "done"),
+            ]
+        )
+        self.assertTrue(receipt_move)
+        receipt_move.value = -100.0
+
+        # Writing that balance off also moves the product's global average,
+        # and the average is recomputed again while the transfer is processed,
+        # so no particular figure is asserted here: what the fix owes is a
+        # positive cost and an entry that runs the right way round.
+        move = self._transfer(self.location1, self.location2, 10.0)
+
+        self.assertEqual(move.l10n_ro_move_type, "internal_transfer")
+        # Falls back to the standard valuation instead of the negative
+        # per-warehouse cost (-10), so the value stays positive. Unguarded,
+        # the move came out at -100.
+        self.assertGreater(move.value, 0.0)
+
+        # And the entry runs the right way round: the source warehouse is
+        # credited for the value of the move. Unguarded, the whole entry ran
+        # backwards - the source warehouse came out debited by 100.
+        account_move = move.account_move_id
+        self.assertTrue(account_move)
+        source_lines = account_move.line_ids.filtered(
+            lambda line: line.account_id
+            == self.location1.l10n_ro_property_stock_valuation_account_id
+        )
+        self.assertAlmostEqual(sum(source_lines.mapped("balance")), -move.value, 2)


### PR DESCRIPTION
Same class of defect as #1563 on 18.0, on the rewritten 19.0 implementation.

## The problem

`_l10n_ro_get_source_account_unit_cost()` rebuilds the balance of the locations sharing the source valuation account and returns `value / quantity`. It guards against a non-positive **quantity**, but not against a negative **balance**: a warehouse left by earlier mis-valuations with a negative balance and goods still on hand yields a negative cost.

Measured on 19.0, on a warehouse holding 10 pieces for a balance of −100 (a cost of −10 a piece), transferring all 10 out:

| | unguarded | expected |
|---|---|---|
| `move.value` | **−100.00** | positive |
| source warehouse (371001) | **+100.00**, debited | credited |

The negative value runs the whole entry backwards: the source warehouse comes out **debited**, so the transfer deepens its negative balance instead of relieving it. Nothing raises — the move value and its entry stay consistent with each other, they are simply pointed the wrong way.

## The fix

Reject a non-positive cost the same way a non-positive quantity is already rejected, so the standard valuation applies. There is no cost the goods can honestly be taken out of such a warehouse at; the pre-existing imbalance is left for a data correction rather than papered over.

## Tests

New `test_internal_transfer_out_of_a_negative_warehouse` in `TestAVGInternalTransfer`: receives the product in two warehouses, writes off the source warehouse balance to −100 to reproduce the state earlier mis-valuations leave, transfers the goods out and asserts the move value is positive and the source warehouse is credited for it.

The assertions are deliberately behavioural rather than a fixed figure: writing that balance off also moves the product's global average, which is recomputed again while the transfer is processed, so pinning a number would test the fixture rather than the fix.

Verified as a real regression test — against the unpatched code it fails with `AssertionError: -100.0 != ...` on the sign of the value. The three tests of the class pass with the guard in place (`0 failed, 0 error(s) of 3 tests`).
