### PR TITLE
[19.0][IMP] l10n_ro_stock_report: give the storage sheet balance rows their own valued type

### DIFF
--- a/l10n_ro_stock_report/README.rst
+++ b/l10n_ro_stock_report/README.rst
@@ -54,6 +54,24 @@ To install this module, you need to:
 Changelog
 =========
 
+19.0.2.6.0
+----------
+
+- Give the opening and closing balance rows a valued type of their own,
+  ``initial`` and ``final``. This changes the behaviour deliberately
+  kept in 19.0.2.4.1 ("balance rows keep no valued type, as in 18.0,
+  since a balance aggregates several move types"), and the reasoning
+  behind it is worth restating: a balance does aggregate several move
+  types, which is exactly why it should not share a group with the
+  movements whose type could not be determined. Left untyped, both
+  balances fall into the same empty-type bucket as those movements, and
+  grouping by valued type then produces a row showing an opening balance
+  differing from the closing balance with no movement in between - the
+  movements being on the typed rows. Every figure in that row is
+  correct, but accountants read it as a broken sheet and open tickets
+  against it. Typing the balances keeps them legible as balances and
+  leaves the empty-type bucket to mean only what it says.
+
 19.0.2.4.1
 ----------
 

--- a/l10n_ro_stock_report/__manifest__.py
+++ b/l10n_ro_stock_report/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "Romania - Stock Report (Fișă Magazie)",
     "license": "AGPL-3",
-    "version": "19.0.2.5.0",
+    "version": "19.0.2.6.0",
     "countries": ["ro"],
     "author": "Terrabit,NextERP Romania,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",

--- a/l10n_ro_stock_report/readme/HISTORY.md
+++ b/l10n_ro_stock_report/readme/HISTORY.md
@@ -1,3 +1,19 @@
+## 19.0.2.6.0
+
+- Give the opening and closing balance rows a valued type of their own,
+  `initial` and `final`. This changes the behaviour deliberately kept in
+  19.0.2.4.1 ("balance rows keep no valued type, as in 18.0, since a balance
+  aggregates several move types"), and the reasoning behind it is worth
+  restating: a balance does aggregate several move types, which is exactly why
+  it should not share a group with the movements whose type could not be
+  determined. Left untyped, both balances fall into the same empty-type bucket
+  as those movements, and grouping by valued type then produces a row showing an
+  opening balance differing from the closing balance with no movement in
+  between - the movements being on the typed rows. Every figure in that row is
+  correct, but accountants read it as a broken sheet and open tickets against
+  it. Typing the balances keeps them legible as balances and leaves the
+  empty-type bucket to mean only what it says.
+
 ## 19.0.2.4.1
 
 - Fix the storage sheet no longer splitting by valued type. Up to 18.0 the

--- a/l10n_ro_stock_report/report/stock_report.py
+++ b/l10n_ro_stock_report/report/stock_report.py
@@ -16,7 +16,16 @@ from odoo.addons.l10n_ro_stock_account.models.stock_move import MOVE_TYPE
 # valuation onto stock.move, so the same information is read from the stored
 # stock.move.l10n_ro_move_type column. "indefinite" stays as the fallback for
 # moves whose type could not be determined.
-VALUED_TYPE = MOVE_TYPE + [("indefinite", "Indefinite")]
+# The opening and closing balance rows are not movements, so they have no move
+# type to read. They still need a valued type of their own: the sheet groups its
+# rows by valued type, and leaving these NULL files both balances into the same
+# empty-type bucket as the movements whose type is unknown. That bucket then
+# shows an opening and a closing balance that differ with no movement in
+# between - the movements being on the typed rows - which reads as a broken
+# report even though every figure is right.
+BALANCE_TYPE = [("initial", "Initial Balance"), ("final", "Final Balance")]
+
+VALUED_TYPE = MOVE_TYPE + BALANCE_TYPE + [("indefinite", "Indefinite")]
 
 # Movement rows take the valued type from the move; it is not an aggregate, so
 # it has to appear in the GROUP BY of the in/out queries as well.
@@ -264,7 +273,7 @@ class StorageSheet(models.TransientModel):
          insert into l10n_ro_stock_storage_sheet_line
           (report_id, product_id, amount_initial, quantity_initial,
            account_id, date_time, date, reference, document,
-           location_id, categ_id {field})
+           location_id, valued_type, categ_id {field})
 
         select * from(
             SELECT %(report)s as report_id, x.product_id as product_id,
@@ -276,6 +285,7 @@ class StorageSheet(models.TransientModel):
                 %(reference)s as reference,
                 %(reference)s as document,
                 %(location)s as location_id,
+                'initial' as valued_type,
                 x.categ_id as categ_id
                 {select}
             from (
@@ -322,7 +332,7 @@ class StorageSheet(models.TransientModel):
         insert into l10n_ro_stock_storage_sheet_line
           (report_id, product_id, amount_final, quantity_final,
            account_id, date_time, date, reference, document,
-           location_id, categ_id {field})
+           location_id, valued_type, categ_id {field})
         select * from(
             SELECT %(report)s as report_id, x.product_id as product_id,
                 COALESCE(sum(x.amount), 0) as amount_final,
@@ -334,6 +344,7 @@ class StorageSheet(models.TransientModel):
                 %(reference)s as reference,
                 %(reference)s as document,
                 %(location)s as location_id,
+                'final' as valued_type,
                 x.categ_id as categ_id
                 {select}
             from (

--- a/l10n_ro_stock_report/static/description/index.html
+++ b/l10n_ro_stock_report/static/description/index.html
@@ -381,14 +381,15 @@ ul.auto-toc {
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-2">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-3">19.0.2.4.1</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-3">19.0.2.6.0</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-4">19.0.2.4.1</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -408,7 +409,26 @@ ul.auto-toc {
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-2">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-3">19.0.2.4.1</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-3">19.0.2.6.0</a></h3>
+<ul class="simple">
+<li>Give the opening and closing balance rows a valued type of their own,
+<tt class="docutils literal">initial</tt> and <tt class="docutils literal">final</tt>. This changes the behaviour deliberately
+kept in 19.0.2.4.1 (“balance rows keep no valued type, as in 18.0,
+since a balance aggregates several move types”), and the reasoning
+behind it is worth restating: a balance does aggregate several move
+types, which is exactly why it should not share a group with the
+movements whose type could not be determined. Left untyped, both
+balances fall into the same empty-type bucket as those movements, and
+grouping by valued type then produces a row showing an opening balance
+differing from the closing balance with no movement in between - the
+movements being on the typed rows. Every figure in that row is
+correct, but accountants read it as a broken sheet and open tickets
+against it. Typing the balances keeps them legible as balances and
+leaves the empty-type bucket to mean only what it says.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.2.4.1</a></h3>
 <ul class="simple">
 <li>Fix the storage sheet no longer splitting by valued type. Up to 18.0
 the valued type of a line came from the valuation layer
@@ -424,7 +444,7 @@ type, as in 18.0, since a balance aggregates several move types.</li>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-romania/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -432,16 +452,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-6">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Authors</a></h3>
 <ul class="simple">
 <li>Terrabit</li>
 <li>NextERP Romania</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-7">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.terrabit.ro">Terrabit</a>:<ul>
 <li>Dorin Hongu &lt;<a class="reference external" href="mailto:dhongu&#64;gmail.com">dhongu&#64;gmail.com</a>&gt;</li>
@@ -458,7 +478,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 technical issues.</p>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/l10n_ro_stock_report/tests/test_report_stock.py
+++ b/l10n_ro_stock_report/tests/test_report_stock.py
@@ -442,3 +442,61 @@ class TestStockReport(TransactionCase):
         self.assertIn("reception", selection)
         self.assertIn("delivery", selection)
         self.assertIn("indefinite", selection)
+
+    def test_report_balance_lines_have_own_valued_type(self):
+        """The opening and closing balance lines carry their own valued type.
+
+        The balances are not movements, so they have no move type to read. When
+        they are left without a valued type they land in the same empty-type
+        group as the movements of unknown type, and that group then shows an
+        opening balance differing from the closing balance with no movement in
+        between - the movements sitting on the typed rows instead. Every figure
+        is correct, but the sheet reads as broken.
+        """
+        product = self.product_1
+        date_dt = fields.Datetime.now() - timedelta(days=5)
+        date_from = fields.Datetime.now() - timedelta(days=10)
+        date_to = fields.Datetime.now() - timedelta(days=1)
+
+        self._create_receipt(product, 6, date_dt)
+        self._create_delivery(product, 2, date_dt)
+
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.location_id = self.location
+        wizard.product_ids = product
+        wizard.date_from = date_from.date()
+        wizard.date_to = date_to.date()
+        wizard = wizard.save()
+        wizard.button_show_sheet_pdf()
+
+        lines = self.env["l10n.ro.stock.storage.sheet.line"].search(
+            [
+                ("report_id", "=", wizard.id),
+                ("product_id", "=", product.id),
+                ("location_id", "=", self.location.id),
+            ]
+        )
+        self.assertTrue(lines)
+
+        # No report line may be left without a valued type: that is the bucket
+        # the balances used to fall into.
+        self.assertNotIn(
+            False,
+            lines.mapped("valued_type"),
+            "Every storage sheet line must carry a valued type",
+        )
+
+        final_lines = lines.filtered(lambda line: line.valued_type == "final")
+        self.assertTrue(final_lines, "The closing balance line must be typed 'final'")
+        # Receipt of 6 less delivery of 2 left on hand at the end of the period.
+        self.assertEqual(sum(final_lines.mapped("quantity_final")), 4)
+
+        # The balance types must be part of the selection, otherwise the values
+        # cannot be grouped nor read in the user interface.
+        selection = dict(
+            self.env["l10n.ro.stock.storage.sheet.line"]
+            ._fields["valued_type"]
+            .selection
+        )
+        self.assertIn("initial", selection)
+        self.assertIn("final", selection)


### PR DESCRIPTION
## What

The opening and closing balance rows of the storage sheet get a valued type of their own, `initial` and `final`, instead of being left without one.

## Why

Grouping the sheet by valued type currently puts both balances into the same empty-type bucket as the movements whose type could not be determined. That row then shows an opening balance differing from the closing balance with **no movement in between** — the movements sit on the typed rows (`reception`, `delivery`, …). Every figure in the row is correct, but it reads as a broken report: accountants ask why a balance changed with no in/out, and it gets reported as a data bug.

We hit exactly this with a customer, who had already opened a second ticket about it. The values were right in both cases; only the presentation misled.

## Note on the previous decision

This deliberately changes behaviour that `readme/HISTORY.md` records for 19.0.2.4.1:

> Balance rows keep no valued type, as in 18.0, since a balance aggregates several move types.

The premise is correct — a balance does aggregate several move types — but I would argue that is the reason to give it a type of its own rather than to share the bucket whose meaning is "type unknown". Distinguishing "this is a balance" from "this movement has an undetermined type" is what makes the grouped sheet readable. The empty-type bucket is left to mean only what it says.

Flagging this explicitly since it is a behaviour change and not a bugfix, so reviewers can weigh it on those terms. Happy to rework it as an opt-in if maintainers prefer to keep the current grouping as the default.

## Tests

Adds `test_report_balance_lines_have_own_valued_type`, which asserts that no report line is left without a valued type and that the closing balance line is typed `final` with the expected on-hand quantity.

The test was verified to fail without the change:

```
FAIL: TestStockReport.test_report_balance_lines_have_own_valued_type
AssertionError: False unexpectedly found in ['reception', 'delivery', False]
  : Every storage sheet line must carry a valued type
```

`l10n_ro_stock_report` suite: 7 passed with the change.