### PR TITLE
[FIX] l10n_ro_stock_account: dropship moves never book a stock valuation entry

### DIFF
--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -121,6 +121,54 @@ historical dropship moves keep their original (missing) accounting
 entries and require a separate, deliberate regularisation if that
 balance needs to be cleared.
 
+Dropship accounting entries
+---------------------------
+
+The company never physically holds the dropshipped goods (the supplier
+ships straight to the customer), but under Romanian accounting rules
+stock is recognised at the transfer of risks and rewards (OMFP
+1802/2014, pt. 283 para. 1), not at physical possession — the same
+principle behind accounts 327 "Goods in transit" and 357 "Goods held by
+third parties" for stock the company owns without holding. Routing a
+dropship purchase through the stock valuation account rather than
+expensing it directly at the vendor bill also keeps a
+purchase-invoice/sale-invoice timing mismatch (e.g. vendor bill in
+December, customer invoice in January) from misstating the period
+result, per the accrual principle (pt. 53).
+
+Forward move (goods leave to the customer):
+
+===================== ===== ======
+Account               Debit Credit
+===================== ===== ======
+Expense (607)         value 
+Stock valuation (371)       value
+===================== ===== ======
+
+Return move (``dropshipped_return``), storno convention — same accounts
+as the forward move, amount in red, not a debit/credit swap:
+
+===================== ====== ======
+Account               Debit  Credit
+===================== ====== ======
+Expense (607)         −value 
+Stock valuation (371)        −value
+===================== ====== ======
+
+408 "Suppliers - invoices not received" never applies to a dropship
+move: that account is a pivot for goods physically received into a
+warehouse before the vendor bill arrives, and a dropship move never has
+that physical-receipt leg. If the vendor bill is missing at the time of
+the customer sale, the correct counterpart is 327 (a stock-in-transit
+account), not 408.
+
+For the entry above to stay correct in practice: the credit to 371 must
+happen in the same accounting period as the debit from the vendor bill
+and for the same amount, so the account nets to zero for dropship
+traffic at period end; and dropship quantities should flow through a
+distinct location so they never mix into a real warehouse's physical
+inventory count.
+
 Performance notes
 -----------------
 

--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -49,6 +49,8 @@ accounting requirements, providing:
 - Specialized accounts for stock operations
 - Per-location FIFO valuation (vs. Odoo's default company-wide FIFO)
 - Automatic negative stock compensation for FIFO products
+- Stock valuation entries for dropship deliveries, symmetric with
+  regular deliveries
 
 Per-location FIFO
 -----------------
@@ -101,6 +103,24 @@ compensation is detected and not duplicated.
 Controlled by ``res.company.fifo_location_negative_compensation``
 (defaults to ``True`` for Romanian companies, editable per company).
 
+Dropship valuation
+------------------
+
+A dropship move (supplier location straight to a customer location,
+goods never entering the company's own stock) is now valued and
+accounted for the same way a regular delivery is: the vendor bill still
+debits the stock valuation account on receipt, and the module now
+credits that same account and debits the expense account when the goods
+leave to the customer, leaving no residual balance. Without this, the
+stock valuation account accumulated a balance that no longer
+corresponded to any goods on hand, and the cost of the dropshipped goods
+was never recognised as an expense.
+
+This applies to dropship moves validated after the fix is installed;
+historical dropship moves keep their original (missing) accounting
+entries and require a separate, deliberate regularisation if that
+balance needs to be cleared.
+
 Performance notes
 -----------------
 
@@ -123,6 +143,36 @@ Performance notes
 
 Changelog
 =========
+
+19.0.1.7.0
+----------
+
+- Fix missing stock valuation entries for dropshipped stock moves. A
+  move from a supplier location straight to a customer location
+  (dropship) never gets ``stock.move.value`` populated by core
+  ``stock_account``: ``_action_done`` routes it through the same
+  ``moves_in._set_value()`` call used for regular incoming moves (the
+  filter is ``is_in or is_dropship``), but the assignment
+  ``move.value = move._get_value()`` inside ``_set_value`` only runs
+  when ``is_in`` is true, never for a pure dropship move. On top of
+  that, ``_get_l10n_ro_move_type_account_list()`` mapped
+  ``"dropshipped"`` and ``"dropshipped_return"`` to an empty account
+  list, so even a correctly valued move would have produced no
+  accounting line. Combined, the vendor bill kept debiting the stock
+  valuation account (371) on receipt, the customer invoice kept
+  crediting the sale account (707) as usual, but the stock side was
+  never credited back and the cost of goods sold expense account (607)
+  was never debited — the stock valuation account accumulated an
+  ever-growing balance with no goods behind it, and gross margin was
+  permanently overstated by the un-recognised cost. Dropship moves now
+  get ``value`` populated the same way ``internal_transfer`` moves
+  already do in this module, and use the same account mapping as
+  ``delivery``/ ``delivery_return`` (debit expense, credit stock
+  valuation, symmetric on the return). This only affects new moves going
+  forward; historical dropship moves already validated before this fix
+  keep their original (missing) accounting and need a separate,
+  deliberate regularisation entry if the accumulated balance is to be
+  cleared.
 
 19.0.1.5.0
 ----------

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.1.6.0",
+    "version": "19.0.1.7.0",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -299,6 +299,19 @@ class StockMove(models.Model):
             # Since we create double entry throught transfer account
             # we need to set the value to the same as the stock valuation
             move.value = move.sudo()._get_value()
+
+        # Dropship: core stock_account._set_value() includes dropship moves in
+        # the moves_in filter (is_in or is_dropship), but only assigns
+        # move.value when is_in is True. Without this, the accounting entry
+        # generated right after (still inside the same core _action_done())
+        # would see value=0 and be silently skipped.
+        ro_dropship_moves = self.filtered(
+            lambda m: m.is_l10n_ro_record
+            and m.l10n_ro_move_type in ("dropshipped", "dropshipped_return")
+            and not m.value
+        )
+        for move in ro_dropship_moves:
+            move.value = move.sudo()._get_value()
         return res
 
     def _l10n_ro_get_source_account_unit_cost(self):
@@ -515,8 +528,8 @@ class StockMove(models.Model):
             "internal_transit_in": [
                 ("stock_valuation", "l10n_ro_transfer", "value", 1)
             ],
-            "dropshipped": [],
-            "dropshipped_return": [],
+            "dropshipped": [("expense", "stock_valuation", "value", 1)],
+            "dropshipped_return": [("expense", "stock_valuation", "value", -1)],
         }
         return vals.get(self.l10n_ro_move_type, [])
 

--- a/l10n_ro_stock_account/readme/DESCRIPTION.md
+++ b/l10n_ro_stock_account/readme/DESCRIPTION.md
@@ -74,6 +74,48 @@ historical dropship moves keep their original (missing) accounting entries
 and require a separate, deliberate regularisation if that balance needs to
 be cleared.
 
+## Dropship accounting entries
+
+The company never physically holds the dropshipped goods (the supplier
+ships straight to the customer), but under Romanian accounting rules stock
+is recognised at the transfer of risks and rewards (OMFP 1802/2014, pt. 283
+para. 1), not at physical possession — the same principle behind accounts
+327 "Goods in transit" and 357 "Goods held by third parties" for stock the
+company owns without holding. Routing a dropship purchase through the
+stock valuation account rather than expensing it directly at the vendor
+bill also keeps a purchase-invoice/sale-invoice timing mismatch (e.g.
+vendor bill in December, customer invoice in January) from misstating the
+period result, per the accrual principle (pt. 53).
+
+Forward move (goods leave to the customer):
+
+| Account | Debit | Credit |
+|---|---|---|
+| Expense (607) | value | |
+| Stock valuation (371) | | value |
+
+Return move (`dropshipped_return`), storno convention — same accounts as
+the forward move, amount in red, not a debit/credit swap:
+
+| Account | Debit | Credit |
+|---|---|---|
+| Expense (607) | −value | |
+| Stock valuation (371) | | −value |
+
+408 "Suppliers - invoices not received" never applies to a dropship move:
+that account is a pivot for goods physically received into a warehouse
+before the vendor bill arrives, and a dropship move never has that
+physical-receipt leg. If the vendor bill is missing at the time of the
+customer sale, the correct counterpart is 327 (a stock-in-transit
+account), not 408.
+
+For the entry above to stay correct in practice: the credit to 371 must
+happen in the same accounting period as the debit from the vendor bill and
+for the same amount, so the account nets to zero for dropship traffic at
+period end; and dropship quantities should flow through a distinct
+location so they never mix into a real warehouse's physical inventory
+count.
+
 ## Performance notes
 
 - Partial composite index on `stock_move(product_id, location_dest_id,

--- a/l10n_ro_stock_account/readme/DESCRIPTION.md
+++ b/l10n_ro_stock_account/readme/DESCRIPTION.md
@@ -11,6 +11,7 @@ The module extends Odoo's standard stock accounting to meet Romanian accounting 
 - Specialized accounts for stock operations
 - Per-location FIFO valuation (vs. Odoo's default company-wide FIFO)
 - Automatic negative stock compensation for FIFO products
+- Stock valuation entries for dropship deliveries, symmetric with regular deliveries
 
 ## Per-location FIFO
 
@@ -56,6 +57,22 @@ compensation is detected and not duplicated.
 
 Controlled by `res.company.fifo_location_negative_compensation`
 (defaults to `True` for Romanian companies, editable per company).
+
+## Dropship valuation
+
+A dropship move (supplier location straight to a customer location, goods
+never entering the company's own stock) is now valued and accounted for the
+same way a regular delivery is: the vendor bill still debits the stock
+valuation account on receipt, and the module now credits that same account
+and debits the expense account when the goods leave to the customer,
+leaving no residual balance. Without this, the stock valuation account
+accumulated a balance that no longer corresponded to any goods on hand, and
+the cost of the dropshipped goods was never recognised as an expense.
+
+This applies to dropship moves validated after the fix is installed;
+historical dropship moves keep their original (missing) accounting entries
+and require a separate, deliberate regularisation if that balance needs to
+be cleared.
 
 ## Performance notes
 

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,3 +1,29 @@
+## 19.0.1.7.0
+
+- Fix missing stock valuation entries for dropshipped stock moves. A move
+  from a supplier location straight to a customer location (dropship) never
+  gets `stock.move.value` populated by core `stock_account`: `_action_done`
+  routes it through the same `moves_in._set_value()` call used for regular
+  incoming moves (the filter is `is_in or is_dropship`), but the assignment
+  `move.value = move._get_value()` inside `_set_value` only runs when
+  `is_in` is true, never for a pure dropship move. On top of that,
+  `_get_l10n_ro_move_type_account_list()` mapped `"dropshipped"` and
+  `"dropshipped_return"` to an empty account list, so even a correctly
+  valued move would have produced no accounting line. Combined, the vendor
+  bill kept debiting the stock valuation account (371) on receipt, the
+  customer invoice kept crediting the sale account (707) as usual, but the
+  stock side was never credited back and the cost of goods sold expense
+  account (607) was never debited — the stock valuation account accumulated
+  an ever-growing balance with no goods behind it, and gross margin was
+  permanently overstated by the un-recognised cost. Dropship moves now get
+  `value` populated the same way `internal_transfer` moves already do in
+  this module, and use the same account mapping as `delivery`/
+  `delivery_return` (debit expense, credit stock valuation, symmetric on
+  the return). This only affects new moves going forward; historical
+  dropship moves already validated before this fix keep their original
+  (missing) accounting and need a separate, deliberate regularisation
+  entry if the accumulated balance is to be cleared.
+
 ## 19.0.1.5.0
 
 - Keep the standard valuation for an internal transfer whose source warehouse

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -456,6 +456,81 @@ historical dropship moves keep their original (missing) accounting
 entries and require a separate, deliberate regularisation if that
 balance needs to be cleared.</p>
 </div>
+<div class="section" id="dropship-accounting-entries">
+<h2>Dropship accounting entries</h2>
+<p>The company never physically holds the dropshipped goods (the supplier
+ships straight to the customer), but under Romanian accounting rules
+stock is recognised at the transfer of risks and rewards (OMFP
+1802/2014, pt. 283 para. 1), not at physical possession — the same
+principle behind accounts 327 “Goods in transit” and 357 “Goods held by
+third parties” for stock the company owns without holding. Routing a
+dropship purchase through the stock valuation account rather than
+expensing it directly at the vendor bill also keeps a
+purchase-invoice/sale-invoice timing mismatch (e.g. vendor bill in
+December, customer invoice in January) from misstating the period
+result, per the accrual principle (pt. 53).</p>
+<p>Forward move (goods leave to the customer):</p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="66%" />
+<col width="16%" />
+<col width="19%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Account</th>
+<th class="head">Debit</th>
+<th class="head">Credit</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Expense (607)</td>
+<td>value</td>
+<td>&nbsp;</td>
+</tr>
+<tr><td>Stock valuation (371)</td>
+<td>&nbsp;</td>
+<td>value</td>
+</tr>
+</tbody>
+</table>
+<p>Return move (<tt class="docutils literal">dropshipped_return</tt>), storno convention — same accounts
+as the forward move, amount in red, not a debit/credit swap:</p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="64%" />
+<col width="18%" />
+<col width="18%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Account</th>
+<th class="head">Debit</th>
+<th class="head">Credit</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Expense (607)</td>
+<td>−value</td>
+<td>&nbsp;</td>
+</tr>
+<tr><td>Stock valuation (371)</td>
+<td>&nbsp;</td>
+<td>−value</td>
+</tr>
+</tbody>
+</table>
+<p>408 “Suppliers - invoices not received” never applies to a dropship
+move: that account is a pivot for goods physically received into a
+warehouse before the vendor bill arrives, and a dropship move never has
+that physical-receipt leg. If the vendor bill is missing at the time of
+the customer sale, the correct counterpart is 327 (a stock-in-transit
+account), not 408.</p>
+<p>For the entry above to stay correct in practice: the credit to 371 must
+happen in the same accounting period as the debit from the vendor bill
+and for the same amount, so the account nets to zero for dropship
+traffic at period end; and dropship quantities should flow through a
+distinct location so they never mix into a real warehouse’s physical
+inventory count.</p>
+</div>
 <div class="section" id="performance-notes">
 <h2>Performance notes</h2>
 <ul class="simple">

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -390,6 +390,8 @@ accounting requirements, providing:</p>
 <li>Specialized accounts for stock operations</li>
 <li>Per-location FIFO valuation (vs. Odoo’s default company-wide FIFO)</li>
 <li>Automatic negative stock compensation for FIFO products</li>
+<li>Stock valuation entries for dropship deliveries, symmetric with
+regular deliveries</li>
 </ul>
 </div>
 <div class="section" id="per-location-fifo">
@@ -438,6 +440,22 @@ compensation is detected and not duplicated.</p>
 <p>Controlled by <tt class="docutils literal">res.company.fifo_location_negative_compensation</tt>
 (defaults to <tt class="docutils literal">True</tt> for Romanian companies, editable per company).</p>
 </div>
+<div class="section" id="dropship-valuation">
+<h2>Dropship valuation</h2>
+<p>A dropship move (supplier location straight to a customer location,
+goods never entering the company’s own stock) is now valued and
+accounted for the same way a regular delivery is: the vendor bill still
+debits the stock valuation account on receipt, and the module now
+credits that same account and debits the expense account when the goods
+leave to the customer, leaving no residual balance. Without this, the
+stock valuation account accumulated a balance that no longer
+corresponded to any goods on hand, and the cost of the dropshipped goods
+was never recognised as an expense.</p>
+<p>This applies to dropship moves validated after the fix is installed;
+historical dropship moves keep their original (missing) accounting
+entries and require a separate, deliberate regularisation if that
+balance needs to be cleared.</p>
+</div>
 <div class="section" id="performance-notes">
 <h2>Performance notes</h2>
 <ul class="simple">
@@ -464,6 +482,37 @@ Inventory Valuation reports drop from O(N) queries to O(distinct
 </div>
 </div>
 <div class="section" id="section-1">
+<h2>19.0.1.7.0</h2>
+<ul class="simple">
+<li>Fix missing stock valuation entries for dropshipped stock moves. A
+move from a supplier location straight to a customer location
+(dropship) never gets <tt class="docutils literal">stock.move.value</tt> populated by core
+<tt class="docutils literal">stock_account</tt>: <tt class="docutils literal">_action_done</tt> routes it through the same
+<tt class="docutils literal">moves_in._set_value()</tt> call used for regular incoming moves (the
+filter is <tt class="docutils literal">is_in or is_dropship</tt>), but the assignment
+<tt class="docutils literal">move.value = move._get_value()</tt> inside <tt class="docutils literal">_set_value</tt> only runs
+when <tt class="docutils literal">is_in</tt> is true, never for a pure dropship move. On top of
+that, <tt class="docutils literal">_get_l10n_ro_move_type_account_list()</tt> mapped
+<tt class="docutils literal">&quot;dropshipped&quot;</tt> and <tt class="docutils literal">&quot;dropshipped_return&quot;</tt> to an empty account
+list, so even a correctly valued move would have produced no
+accounting line. Combined, the vendor bill kept debiting the stock
+valuation account (371) on receipt, the customer invoice kept
+crediting the sale account (707) as usual, but the stock side was
+never credited back and the cost of goods sold expense account (607)
+was never debited — the stock valuation account accumulated an
+ever-growing balance with no goods behind it, and gross margin was
+permanently overstated by the un-recognised cost. Dropship moves now
+get <tt class="docutils literal">value</tt> populated the same way <tt class="docutils literal">internal_transfer</tt> moves
+already do in this module, and use the same account mapping as
+<tt class="docutils literal">delivery</tt>/ <tt class="docutils literal">delivery_return</tt> (debit expense, credit stock
+valuation, symmetric on the return). This only affects new moves going
+forward; historical dropship moves already validated before this fix
+keep their original (missing) accounting and need a separate,
+deliberate regularisation entry if the accumulated balance is to be
+cleared.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h2>19.0.1.5.0</h2>
 <ul class="simple">
 <li>Keep the standard valuation for an internal transfer whose source
@@ -476,7 +525,7 @@ of credited, so the transfer deepened its negative balance instead of
 relieving it.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h2>19.0.1.3.0</h2>
 <ul class="simple">
 <li>Value an internal transfer at the cost the source warehouse actually
@@ -506,7 +555,7 @@ different mechanism: on this series the valuation layer is gone and
 the value lives on the move.</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h2>19.0.1.1.1</h2>
 <ul class="simple">
 <li>Fix silent over-delivery in <tt class="docutils literal">stock_move._split_for_fifo_assignment</tt>:
@@ -531,7 +580,7 @@ instead of silently completing the transfer if the amount accounted
 for by the split still doesn’t match.</li>
 </ul>
 </div>
-<div class="section" id="section-4">
+<div class="section" id="section-5">
 <h2>19.0.1.0.0</h2>
 <ul class="simple">
 <li>Recognise the exchange rate difference on the 408 pivot (<em>Furnizori -
@@ -564,7 +613,7 @@ difference, whose liability arises at the invoice date - is taken at
 the invoice rate.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
+<div class="section" id="section-6">
 <h2>19.0.0.26.1</h2>
 <ul class="simple">
 <li>Expose the <tt class="docutils literal">stock.move.l10n_ro_move_type</tt> selection as the module
@@ -573,7 +622,7 @@ duplicating the list. Up to 18.0 the same list was available as
 <tt class="docutils literal">VALUED_TYPE</tt> on <tt class="docutils literal">stock.valuation.layer</tt>. No functional change.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
+<div class="section" id="section-7">
 <h2>19.0.0.25.1</h2>
 <ul class="simple">
 <li>Fix <tt class="docutils literal">IndexError: list index out of range</tt> in
@@ -588,7 +637,7 @@ the quantities are compared with the UoM rounding instead of raw
 floats.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
+<div class="section" id="section-8">
 <h2>19.0.0.19.1</h2>
 <ul class="simple">
 <li>Fix

--- a/l10n_ro_stock_account/tests/__init__.py
+++ b/l10n_ro_stock_account/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_stock_fifo_internal_transfer
 from . import test_avg_internal_transfer
 from . import test_stock_location
 from . import test_notice_currency
+from . import test_ro_stock_dropship

--- a/l10n_ro_stock_account/tests/test_ro_stock_dropship.py
+++ b/l10n_ro_stock_account/tests/test_ro_stock_dropship.py
@@ -1,0 +1,117 @@
+# Copyright (C) 2026 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import Form, tagged
+
+from .common import TestROStockCommon
+
+
+@tagged("post_install", "-at_install")
+class TestROStockDropship(TestROStockCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.dropship_route = cls.env.ref("stock_dropshipping.route_drop_shipping")
+        cls.env["product.supplierinfo"].create(
+            {
+                "partner_id": cls.supplier_1.id,
+                "product_tmpl_id": cls.product_fifo.product_tmpl_id.id,
+                "price": 100.0,
+            }
+        )
+        cls.env.user.group_ids += cls.env.ref("stock.group_adv_location")
+
+    def _create_and_validate_dropship(self, qty=5.0):
+        so_form = Form(self.env["sale.order"])
+        so_form.partner_id = self.customer_1
+        with so_form.order_line.new() as line:
+            line.product_id = self.product_fifo
+            line.product_uom_qty = qty
+        so = so_form.save()
+        so.order_line.write({"route_ids": [(6, 0, self.dropship_route.ids)]})
+        so.action_confirm()
+
+        po = self.env["purchase.order"].search(
+            [("partner_id", "=", self.supplier_1.id), ("origin", "=", so.name)]
+        )
+        self.assertTrue(po, "A Purchase Order should be created for the dropship line")
+        po.button_confirm()
+
+        picking = po.picking_ids
+        self.assertTrue(picking, "A dropship picking should be created")
+        self.assertEqual(picking.picking_type_id.code, "dropship")
+
+        picking.move_ids.quantity = qty
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+
+        return picking.move_ids
+
+    def test_dropship_generates_valuation_entry(self):
+        """A dropship delivery must credit the stock valuation account (371)
+        and debit the expense account (607), symmetric with a regular
+        delivery — instead of leaving the vendor bill's debit into 371
+        uncompensated."""
+        move = self._create_and_validate_dropship(qty=5.0)
+        self.assertEqual(move.l10n_ro_move_type, "dropshipped")
+
+        expected_value = move.purchase_line_id.price_unit * 5.0
+        self.assertAlmostEqual(
+            move.value,
+            expected_value,
+            places=2,
+            msg="stock.move.value must be populated for a dropship move, "
+            "not left at 0 as core stock_account leaves it",
+        )
+
+        self.assertTrue(
+            move.account_move_id,
+            "A dropship move must generate its own accounting entry",
+        )
+        lines = move.account_move_id.line_ids
+        self.assertEqual(len(lines), 2)
+
+        debit_line = lines.filtered(lambda line: line.debit > 0)
+        credit_line = lines.filtered(lambda line: line.credit > 0)
+        self.assertEqual(debit_line.account_id, self.account_expense)
+        self.assertEqual(credit_line.account_id, self.account_valuation)
+        self.assertAlmostEqual(debit_line.debit, expected_value, places=2)
+        self.assertAlmostEqual(credit_line.credit, expected_value, places=2)
+
+    def test_dropship_return_reverses_valuation_entry(self):
+        """A dropship return move must storno the original entry: same
+        accounts as a forward dropship move (debit expense / credit stock
+        valuation), with the amount in red (negative), per the Romanian
+        storno convention already used by "delivery_return"."""
+        move = self._create_and_validate_dropship(qty=3.0)
+        original_value = move.value
+
+        return_wizard = (
+            self.env["stock.return.picking"]
+            .with_context(active_id=move.picking_id.id, active_model="stock.picking")
+            .create({})
+        )
+        return_wizard.product_return_moves.quantity = 3.0
+        return_picking = return_wizard._create_return()
+        return_picking.move_ids.quantity = 3.0
+        return_picking.button_validate()
+
+        return_move = return_picking.move_ids
+        self.assertEqual(return_move.l10n_ro_move_type, "dropshipped_return")
+        self.assertTrue(
+            return_move.account_move_id,
+            "A dropship return move must generate its own accounting entry",
+        )
+
+        lines = return_move.account_move_id.line_ids
+        expense_line = lines.filtered(
+            lambda line: line.account_id == self.account_expense
+        )
+        valuation_line = lines.filtered(
+            lambda line: line.account_id == self.account_valuation
+        )
+        self.assertTrue(expense_line and valuation_line)
+        self.assertTrue(expense_line.is_storno)
+        self.assertTrue(valuation_line.is_storno)
+        self.assertAlmostEqual(expense_line.debit, -original_value, places=2)
+        self.assertAlmostEqual(valuation_line.credit, -original_value, places=2)


### PR DESCRIPTION
## Problem

A dropship move (supplier location straight to a customer location, goods
never entering the company's own stock) never gets a stock valuation
accounting entry on Romanian-accounted companies. Confirmed on real
production data: 100% of ~6,000 historical `dropshipped`/`dropshipped_return`
stock moves had `account_move_id` empty, with zero overlap against existing
607 (COGS) journal entries on the same sale lines.

Effect: the vendor bill still debits the stock valuation account (371) on
receipt (this module forces storable purchase lines onto the stock account
regardless of move type — see `_get_l10n_ro_line_account`), and the customer
invoice still credits the sale account (707) as usual, but the stock side is
never credited back and the cost of goods sold account (607) is never
debited. The stock valuation account accumulates a balance with no goods
behind it, and gross margin is permanently overstated by the un-recognised
cost.

## Root cause — two overlapping causes

1. `_get_l10n_ro_move_type_account_list()` mapped `"dropshipped"` and
   `"dropshipped_return"` to an **empty account list**, unlike `"delivery"`/
   `"delivery_return"`.
2. Deeper cause, found while fixing (1) alone turned out to have no effect):
   core `stock_account`'s `_set_value()` includes dropship moves in the same
   `moves_in` filter as regular incoming moves (`is_in or is_dropship`), but
   the actual `move.value = move._get_value()` assignment only runs
   `if move.is_in:` — never for a pure dropship move. So even with (1) fixed,
   the generated line would see `value == 0` and be silently skipped
   (`if not value: continue`).

## Fix

- Extended this module's existing `_set_value()` override (already handling
  `internal_transfer` the same way) to also populate `.value` for dropship
  moves.
- Populated the `"dropshipped"`/`"dropshipped_return"` account mapping with
  the same tuples as `"delivery"`/`"delivery_return"` (debit expense, credit
  stock valuation, storno on the return).

This only affects moves validated after the fix; historical dropship moves
keep their original (missing) accounting and need a separate, deliberate
regularisation entry if the accumulated balance is to be cleared.

## Testing

Added `tests/test_ro_stock_dropship.py` (forward delivery + return), both
passing. Full `l10n_ro_stock_account` test suite (31 tests / 51 sub-cases)
passes with no regressions.