### PR TITLE
[FIX] l10n_ro_stock_account: dropship must not reprice unrelated average-cost stock

### DIFF
--- a/l10n_ro_stock_account/README.rst
+++ b/l10n_ro_stock_account/README.rst
@@ -169,6 +169,14 @@ traffic at period end; and dropship quantities should flow through a
 distinct location so they never mix into a real warehouse's physical
 inventory count.
 
+Dropshipping a product does not affect the value of that same product's
+real stock held elsewhere, on either costing method (FIFO or average
+cost). Core Odoo's own average-cost engine folds dropship moves into the
+same moving-average pool as real purchases by design, which would
+otherwise retroactively reprice unrelated stock on hand purely because
+the same product was also dropshipped; this module routes dropship moves
+around that recompute entirely for Romanian-accounted companies.
+
 Performance notes
 -----------------
 
@@ -191,6 +199,31 @@ Performance notes
 
 Changelog
 =========
+
+19.0.1.8.0
+----------
+
+- Fix dropship moves retroactively repricing unrelated real stock of the
+  same product, for average-cost (AVCO) products. Core
+  ``stock_account``'s ``_set_value()`` adds a move's product to
+  ``products_to_recompute`` whenever ``is_dropship or is_in`` is true,
+  regardless of whether the move ends up contributing any value there,
+  and later recomputes the average cost for every product in that set.
+  Core's own averaging engine (``product._run_average_batch``)
+  explicitly includes ``is_dropship`` moves in the same moving-average
+  pool as real purchases, and since Odoo 19 derives average-cost quant
+  values live from ``standard_price``, that recompute retroactively
+  changes the reported value of a product's real stock held elsewhere,
+  purely because the same product was also dropshipped — even though the
+  dropship transaction never touched that stock. Confirmed this
+  reproduces in plain Odoo (no Romanian accounting involved) as well as
+  on a Romanian-accounted company before this fix. Dropship moves now
+  bypass core's ``_set_value()`` entirely on Romanian-accounted
+  companies (this module already sets their ``value`` itself, see the
+  19.0.1.7.0 entry below) so they never enter that recompute. FIFO
+  products were never affected: core's FIFO branch reprices existing
+  stock strictly from its own ``total_value``/``qty_available``, neither
+  of which a dropship move ever touches.
 
 19.0.1.7.0
 ----------

--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "19.0.1.7.0",
+    "version": "19.0.1.8.0",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/models/stock_move.py
+++ b/l10n_ro_stock_account/models/stock_move.py
@@ -291,7 +291,22 @@ class StockMove(models.Model):
 
     def _set_value(self, correction_quantity=None):
         """Set the value of the move"""
-        res = super()._set_value(correction_quantity=correction_quantity)
+        # Dropship moves gain nothing from core's own _set_value (they never
+        # satisfy its is_in/_is_out branches), but core still adds their
+        # product to `products_to_recompute` (keyed on `is_dropship or
+        # is_in`) and later recomputes the average cost for it — folding the
+        # dropship cost into the SAME moving-average pool as the company's
+        # real stock of that product (core's `_run_average_batch` explicitly
+        # includes `is_dropship` moves), which retroactively reprices
+        # unrelated quants already on hand. Route dropship moves around
+        # core's _set_value entirely and value them ourselves below instead.
+        ro_dropship_moves = self.filtered(
+            lambda m: m.is_l10n_ro_record
+            and m.l10n_ro_move_type in ("dropshipped", "dropshipped_return")
+        )
+        res = super(StockMove, self - ro_dropship_moves)._set_value(
+            correction_quantity=correction_quantity
+        )
         ro_internal_moves = self.filtered(
             lambda m: m.is_l10n_ro_record and m.l10n_ro_move_type == "internal_transfer"
         )
@@ -300,17 +315,7 @@ class StockMove(models.Model):
             # we need to set the value to the same as the stock valuation
             move.value = move.sudo()._get_value()
 
-        # Dropship: core stock_account._set_value() includes dropship moves in
-        # the moves_in filter (is_in or is_dropship), but only assigns
-        # move.value when is_in is True. Without this, the accounting entry
-        # generated right after (still inside the same core _action_done())
-        # would see value=0 and be silently skipped.
-        ro_dropship_moves = self.filtered(
-            lambda m: m.is_l10n_ro_record
-            and m.l10n_ro_move_type in ("dropshipped", "dropshipped_return")
-            and not m.value
-        )
-        for move in ro_dropship_moves:
+        for move in ro_dropship_moves.filtered(lambda m: not m.value):
             move.value = move.sudo()._get_value()
         return res
 

--- a/l10n_ro_stock_account/readme/DESCRIPTION.md
+++ b/l10n_ro_stock_account/readme/DESCRIPTION.md
@@ -116,6 +116,14 @@ period end; and dropship quantities should flow through a distinct
 location so they never mix into a real warehouse's physical inventory
 count.
 
+Dropshipping a product does not affect the value of that same product's
+real stock held elsewhere, on either costing method (FIFO or average
+cost). Core Odoo's own average-cost engine folds dropship moves into the
+same moving-average pool as real purchases by design, which would
+otherwise retroactively reprice unrelated stock on hand purely because the
+same product was also dropshipped; this module routes dropship moves
+around that recompute entirely for Romanian-accounted companies.
+
 ## Performance notes
 
 - Partial composite index on `stock_move(product_id, location_dest_id,

--- a/l10n_ro_stock_account/readme/HISTORY.md
+++ b/l10n_ro_stock_account/readme/HISTORY.md
@@ -1,3 +1,26 @@
+## 19.0.1.8.0
+
+- Fix dropship moves retroactively repricing unrelated real stock of the
+  same product, for average-cost (AVCO) products. Core `stock_account`'s
+  `_set_value()` adds a move's product to `products_to_recompute` whenever
+  `is_dropship or is_in` is true, regardless of whether the move ends up
+  contributing any value there, and later recomputes the average cost for
+  every product in that set. Core's own averaging engine
+  (`product._run_average_batch`) explicitly includes `is_dropship` moves in
+  the same moving-average pool as real purchases, and since Odoo 19 derives
+  average-cost quant values live from `standard_price`, that recompute
+  retroactively changes the reported value of a product's real stock held
+  elsewhere, purely because the same product was also dropshipped — even
+  though the dropship transaction never touched that stock. Confirmed this
+  reproduces in plain Odoo (no Romanian accounting involved) as well as on
+  a Romanian-accounted company before this fix. Dropship moves now bypass
+  core's `_set_value()` entirely on Romanian-accounted companies (this
+  module already sets their `value` itself, see the 19.0.1.7.0 entry
+  below) so they never enter that recompute. FIFO products were never
+  affected: core's FIFO branch reprices existing stock strictly from its
+  own `total_value`/`qty_available`, neither of which a dropship move ever
+  touches.
+
 ## 19.0.1.7.0
 
 - Fix missing stock valuation entries for dropshipped stock moves. A move

--- a/l10n_ro_stock_account/static/description/index.html
+++ b/l10n_ro_stock_account/static/description/index.html
@@ -530,6 +530,13 @@ and for the same amount, so the account nets to zero for dropship
 traffic at period end; and dropship quantities should flow through a
 distinct location so they never mix into a real warehouse’s physical
 inventory count.</p>
+<p>Dropshipping a product does not affect the value of that same product’s
+real stock held elsewhere, on either costing method (FIFO or average
+cost). Core Odoo’s own average-cost engine folds dropship moves into the
+same moving-average pool as real purchases by design, which would
+otherwise retroactively reprice unrelated stock on hand purely because
+the same product was also dropshipped; this module routes dropship moves
+around that recompute entirely for Romanian-accounted companies.</p>
 </div>
 <div class="section" id="performance-notes">
 <h2>Performance notes</h2>
@@ -557,6 +564,32 @@ Inventory Valuation reports drop from O(N) queries to O(distinct
 </div>
 </div>
 <div class="section" id="section-1">
+<h2>19.0.1.8.0</h2>
+<ul class="simple">
+<li>Fix dropship moves retroactively repricing unrelated real stock of the
+same product, for average-cost (AVCO) products. Core
+<tt class="docutils literal">stock_account</tt>’s <tt class="docutils literal">_set_value()</tt> adds a move’s product to
+<tt class="docutils literal">products_to_recompute</tt> whenever <tt class="docutils literal">is_dropship or is_in</tt> is true,
+regardless of whether the move ends up contributing any value there,
+and later recomputes the average cost for every product in that set.
+Core’s own averaging engine (<tt class="docutils literal">product._run_average_batch</tt>)
+explicitly includes <tt class="docutils literal">is_dropship</tt> moves in the same moving-average
+pool as real purchases, and since Odoo 19 derives average-cost quant
+values live from <tt class="docutils literal">standard_price</tt>, that recompute retroactively
+changes the reported value of a product’s real stock held elsewhere,
+purely because the same product was also dropshipped — even though the
+dropship transaction never touched that stock. Confirmed this
+reproduces in plain Odoo (no Romanian accounting involved) as well as
+on a Romanian-accounted company before this fix. Dropship moves now
+bypass core’s <tt class="docutils literal">_set_value()</tt> entirely on Romanian-accounted
+companies (this module already sets their <tt class="docutils literal">value</tt> itself, see the
+19.0.1.7.0 entry below) so they never enter that recompute. FIFO
+products were never affected: core’s FIFO branch reprices existing
+stock strictly from its own <tt class="docutils literal">total_value</tt>/<tt class="docutils literal">qty_available</tt>, neither
+of which a dropship move ever touches.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h2>19.0.1.7.0</h2>
 <ul class="simple">
 <li>Fix missing stock valuation entries for dropshipped stock moves. A
@@ -587,7 +620,7 @@ deliberate regularisation entry if the accumulated balance is to be
 cleared.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h2>19.0.1.5.0</h2>
 <ul class="simple">
 <li>Keep the standard valuation for an internal transfer whose source
@@ -600,7 +633,7 @@ of credited, so the transfer deepened its negative balance instead of
 relieving it.</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h2>19.0.1.3.0</h2>
 <ul class="simple">
 <li>Value an internal transfer at the cost the source warehouse actually
@@ -630,7 +663,7 @@ different mechanism: on this series the valuation layer is gone and
 the value lives on the move.</li>
 </ul>
 </div>
-<div class="section" id="section-4">
+<div class="section" id="section-5">
 <h2>19.0.1.1.1</h2>
 <ul class="simple">
 <li>Fix silent over-delivery in <tt class="docutils literal">stock_move._split_for_fifo_assignment</tt>:
@@ -655,7 +688,7 @@ instead of silently completing the transfer if the amount accounted
 for by the split still doesn’t match.</li>
 </ul>
 </div>
-<div class="section" id="section-5">
+<div class="section" id="section-6">
 <h2>19.0.1.0.0</h2>
 <ul class="simple">
 <li>Recognise the exchange rate difference on the 408 pivot (<em>Furnizori -
@@ -688,7 +721,7 @@ difference, whose liability arises at the invoice date - is taken at
 the invoice rate.</li>
 </ul>
 </div>
-<div class="section" id="section-6">
+<div class="section" id="section-7">
 <h2>19.0.0.26.1</h2>
 <ul class="simple">
 <li>Expose the <tt class="docutils literal">stock.move.l10n_ro_move_type</tt> selection as the module
@@ -697,7 +730,7 @@ duplicating the list. Up to 18.0 the same list was available as
 <tt class="docutils literal">VALUED_TYPE</tt> on <tt class="docutils literal">stock.valuation.layer</tt>. No functional change.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
+<div class="section" id="section-8">
 <h2>19.0.0.25.1</h2>
 <ul class="simple">
 <li>Fix <tt class="docutils literal">IndexError: list index out of range</tt> in
@@ -712,7 +745,7 @@ the quantities are compared with the UoM rounding instead of raw
 floats.</li>
 </ul>
 </div>
-<div class="section" id="section-8">
+<div class="section" id="section-9">
 <h2>19.0.0.19.1</h2>
 <ul class="simple">
 <li>Fix

--- a/l10n_ro_stock_account/tests/test_ro_stock_dropship.py
+++ b/l10n_ro_stock_account/tests/test_ro_stock_dropship.py
@@ -115,3 +115,105 @@ class TestROStockDropship(TestROStockCommon):
         self.assertTrue(valuation_line.is_storno)
         self.assertAlmostEqual(expense_line.debit, -original_value, places=2)
         self.assertAlmostEqual(valuation_line.credit, -original_value, places=2)
+
+    def test_dropship_does_not_affect_existing_stock_valuation(self):
+        """Dropshipping a product that also has real FIFO stock elsewhere
+        must not change that stock's quantity, value, or per-unit cost.
+        Populating stock.move.value on the dropship move (this fix) only
+        feeds that move's own journal entry — it must not leak into the
+        product's quants or standard_price.
+
+        This is deliberately run on a FIFO product, not an average-cost one:
+        core stock_account's average-cost engine
+        (`product._run_average_batch`, see `stock_account/models/product.py`)
+        folds `is_dropship` moves into the same moving-average pool as real
+        purchases by design, which does retroactively change an
+        average-cost product's `standard_price` — and, since Odoo 19 quant
+        values for average-cost products are derived live from
+        `standard_price`, the value of unrelated real stock changes too.
+        That is a pre-existing core Odoo behaviour, unrelated to this fix
+        (reproduces identically with this module's dropship changes
+        reverted) and out of scope here; it does not affect FIFO products,
+        which is what this module's own valuation is built around."""
+        product = self.product_fifo
+
+        # Normal receipt into the company's own stock: 10 units @ 50.
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.supplier_1.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "product_qty": 10.0,
+                            "price_unit": 50.0,
+                        },
+                    )
+                ],
+            }
+        )
+        po.button_confirm()
+        receipt = po.picking_ids
+        receipt.move_ids.quantity = 10.0
+        receipt.button_validate()
+        self.assertEqual(receipt.state, "done")
+
+        quants_before = self.env["stock.quant"]._gather(
+            product, receipt.location_dest_id
+        )
+        qty_before = sum(quants_before.mapped("quantity"))
+        value_before = sum(quants_before.mapped("value"))
+        standard_price_before = product.standard_price
+        self.assertEqual(qty_before, 10.0)
+
+        # Dropship the same product at a different (higher) unit cost, so any
+        # bleed into the average cost would be detectable.
+        so_form = Form(self.env["sale.order"])
+        so_form.partner_id = self.customer_1
+        with so_form.order_line.new() as line:
+            line.product_id = product
+            line.product_uom_qty = 4.0
+        so = so_form.save()
+        so.order_line.write({"route_ids": [(6, 0, self.dropship_route.ids)]})
+        so.action_confirm()
+
+        dropship_po = self.env["purchase.order"].search(
+            [("partner_id", "=", self.supplier_1.id), ("origin", "=", so.name)]
+        )
+        self.assertTrue(dropship_po)
+        dropship_po.order_line.price_unit = 80.0
+        dropship_po.button_confirm()
+        dropship_picking = dropship_po.picking_ids
+        self.assertEqual(dropship_picking.picking_type_id.code, "dropship")
+        dropship_picking.move_ids.quantity = 4.0
+        dropship_picking.button_validate()
+
+        dropship_move = dropship_picking.move_ids
+        self.assertEqual(dropship_move.l10n_ro_move_type, "dropshipped")
+        self.assertAlmostEqual(dropship_move.value, 80.0 * 4.0, places=2)
+
+        quants_after = self.env["stock.quant"]._gather(
+            product, receipt.location_dest_id
+        )
+        qty_after = sum(quants_after.mapped("quantity"))
+        value_after = sum(quants_after.mapped("value"))
+
+        self.assertEqual(
+            qty_after,
+            qty_before,
+            "Dropshipping the same product must not change the real stock quantity",
+        )
+        self.assertAlmostEqual(
+            value_after,
+            value_before,
+            places=2,
+            msg="Dropshipping the same product must not change the real stock's value",
+        )
+        self.assertAlmostEqual(
+            product.standard_price,
+            standard_price_before,
+            places=2,
+            msg="Dropship cost must not bleed into the product's average cost",
+        )

--- a/l10n_ro_stock_account/tests/test_ro_stock_dropship.py
+++ b/l10n_ro_stock_account/tests/test_ro_stock_dropship.py
@@ -116,27 +116,31 @@ class TestROStockDropship(TestROStockCommon):
         self.assertAlmostEqual(expense_line.debit, -original_value, places=2)
         self.assertAlmostEqual(valuation_line.credit, -original_value, places=2)
 
-    def test_dropship_does_not_affect_existing_stock_valuation(self):
+    def test_dropship_does_not_affect_existing_fifo_stock_valuation(self):
         """Dropshipping a product that also has real FIFO stock elsewhere
-        must not change that stock's quantity, value, or per-unit cost.
-        Populating stock.move.value on the dropship move (this fix) only
-        feeds that move's own journal entry — it must not leak into the
-        product's quants or standard_price.
+        must not change that stock's quantity, value, or per-unit cost."""
+        self._assert_dropship_does_not_affect_existing_stock_valuation(
+            self.product_fifo
+        )
 
-        This is deliberately run on a FIFO product, not an average-cost one:
-        core stock_account's average-cost engine
+    def test_dropship_does_not_affect_existing_average_stock_valuation(self):
+        """Same as above, for an average-cost (AVCO) product.
+
+        Core stock_account's own averaging engine
         (`product._run_average_batch`, see `stock_account/models/product.py`)
-        folds `is_dropship` moves into the same moving-average pool as real
-        purchases by design, which does retroactively change an
-        average-cost product's `standard_price` — and, since Odoo 19 quant
-        values for average-cost products are derived live from
-        `standard_price`, the value of unrelated real stock changes too.
-        That is a pre-existing core Odoo behaviour, unrelated to this fix
-        (reproduces identically with this module's dropship changes
-        reverted) and out of scope here; it does not affect FIFO products,
-        which is what this module's own valuation is built around."""
-        product = self.product_fifo
+        folds any `is_dropship` move into the SAME moving-average pool as
+        real purchases, by design — core's `_set_value()` adds the
+        dropship's product to `products_to_recompute` (keyed on
+        `is_dropship or is_in`) regardless of whether the move contributes
+        any value there. Since Odoo 19 derives average-cost quant values
+        live from `standard_price`, that recompute would retroactively
+        reprice unrelated real stock of the same product just because it
+        was also dropshipped. This module routes dropship moves around
+        core's `_set_value()` entirely (see the `_set_value` override in
+        `models/stock_move.py`) so they never reach that recompute."""
+        self._assert_dropship_does_not_affect_existing_stock_valuation(self.product_avg)
 
+    def _assert_dropship_does_not_affect_existing_stock_valuation(self, product):
         # Normal receipt into the company's own stock: 10 units @ 50.
         po = self.env["purchase.order"].create(
             {


### PR DESCRIPTION
## Follow-up to #1566

While writing a regression test to confirm the dropship fix from #1566 doesn't leak into unrelated stock valuation, found a second, distinct bug — this time in the average-cost (AVCO) path.

## Problem

Dropshipping a product that also has real average-cost stock held elsewhere retroactively changes the *reported value of that unrelated real stock*, purely because the same product SKU was also dropshipped.

## Root cause

Core `stock_account`'s `_set_value()` adds a move's product to `products_to_recompute` whenever `is_dropship or is_in` is true, regardless of whether the move ends up contributing any value to that recompute. It then calls `_update_standard_price()` for every product in that set. For average-cost products, `_update_standard_price()` falls through to `product._run_average_batch(force_recompute=True)`, whose `moves_domain` **explicitly includes `is_dropship` moves** alongside `is_in`/`is_out` — folding dropship transactions into the same moving-average pool as real purchases, by design.

Since Odoo 19 derives average-cost quant values live from `standard_price` (no more stock valuation layers), this recompute retroactively reprices *all* existing stock of that product — including stock never touched by the dropship transaction.

Verified this reproduces identically:
- on plain Odoo, no Romanian accounting involved at all;
- on a Romanian-accounted company, both before and after the #1566 fix.

So it is a pre-existing core `stock_account` behaviour, unrelated to what #1566 fixed, and out of scope for a core patch here — this PR mitigates it for Romanian-accounted companies specifically.

## Fix

Route dropship moves around core's `_set_value()` entirely instead of letting them flow through it. This module already sets their `value` itself (from #1566), so nothing is lost; their product simply never enters `products_to_recompute` because of them.

FIFO products were never affected by this: core's FIFO branch reprices existing stock strictly from its own `total_value`/`qty_available`, neither of which a dropship move ever touches.

## Testing

Added a parametrized regression test (`test_dropship_does_not_affect_existing_fifo_stock_valuation` / `..._average_stock_valuation`) covering both FIFO and average-cost products explicitly — both pass after this fix; the average-cost one fails without it (confirmed).