### PR TITLE
[19.0][FIX] l10n_ro_stock_report: translate missing valued_type labels to Romanian

### DIFF
--- a/l10n_ro_stock_report/i18n/ro.po
+++ b/l10n_ro_stock_report/i18n/ro.po
@@ -89,7 +89,7 @@ msgstr "Consum"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__consumption_return
 msgid "Consumption Return"
-msgstr ""
+msgstr "Returnare Consum"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet__create_uid
@@ -142,17 +142,17 @@ msgstr "Livrare"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__delivery_notice
 msgid "Delivery Notice"
-msgstr ""
+msgstr "Aviz de Livrare"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__delivery_notice_return
 msgid "Delivery Notice Return"
-msgstr ""
+msgstr "Returnare Aviz de Livrare"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__delivery_return
 msgid "Delivery Return"
-msgstr ""
+msgstr "Returnare Livrare"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet__detailed_locations
@@ -178,7 +178,7 @@ msgstr "Livrare directă"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__dropshipped_return
 msgid "Dropshipped Return"
-msgstr ""
+msgstr "Returnare Livrare Directă"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet__date_to
@@ -198,7 +198,7 @@ msgstr "Valoare finală"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__final
 msgid "Final Balance"
-msgstr ""
+msgstr "Sold final"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet_line__quantity_final
@@ -234,7 +234,7 @@ msgstr "Valoare inițială"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__initial
 msgid "Initial Balance"
-msgstr ""
+msgstr "Sold inițial"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet_line__quantity_initial
@@ -264,7 +264,7 @@ msgstr "Intrare tranzit intern"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__internal_transit_out
 msgid "Internal Transit Out"
-msgstr ""
+msgstr "Tranzit Intern Ieșire"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet_line__invoice_id
@@ -299,7 +299,7 @@ msgstr "Locație"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__minus_inventory
 msgid "Minus Inventory"
-msgstr ""
+msgstr "Minus Inventar"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet__one_product
@@ -334,7 +334,7 @@ msgstr "Partener"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__plus_inventory
 msgid "Plus Inventory"
-msgstr ""
+msgstr "Plus Inventar"
 
 #. module: l10n_ro_stock_report
 #: model_terms:ir.ui.view,arch_db:l10n_ro_stock_report.report_storage_sheet_lines_header
@@ -370,7 +370,7 @@ msgstr "Producție"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__production_return
 msgid "Production Return"
-msgstr ""
+msgstr "Returnare Producție"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet__products_with_move
@@ -400,27 +400,27 @@ msgstr "Recepţie"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__reception_in_progress
 msgid "Reception In Progress"
-msgstr ""
+msgstr "Recepție în curs"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__reception_in_progress_return
 msgid "Reception In Progress Return"
-msgstr ""
+msgstr "Returnare Recepție în curs"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__reception_notice
 msgid "Reception Notice"
-msgstr ""
+msgstr "Aviz de Recepție"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__reception_notice_return
 msgid "Reception Notice Return"
-msgstr ""
+msgstr "Returnare Aviz de Recepție"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__reception_return
 msgid "Reception Return"
-msgstr ""
+msgstr "Returnare Recepție"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet_line__reference
@@ -519,7 +519,7 @@ msgstr "Utilizare de"
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields.selection,name:l10n_ro_stock_report.selection__l10n_ro_stock_storage_sheet_line__valued_type__usage_giving_return
 msgid "Usage Giving Return"
-msgstr ""
+msgstr "Returnare Dare în Utilizare"
 
 #. module: l10n_ro_stock_report
 #: model:ir.model.fields,field_description:l10n_ro_stock_report.field_l10n_ro_stock_storage_sheet_line__valued_type


### PR DESCRIPTION
## Summary
- Several `valued_type` selection labels in `l10n_ro_stock_report` had an empty `msgstr` in `i18n/ro.po`, so they rendered in English inside an otherwise fully Romanian storage sheet report: `Initial Balance`, `Final Balance`, `Reception Return`, `Delivery Return`, `Minus Inventory`, `Plus Inventory`, and 9 other move-type labels.
- The same English strings already have an approved Romanian translation in `l10n_ro_stock_account`'s `ro.po` (the module that originally defines the move types) — this PR ports those existing translations into `l10n_ro_stock_report`'s own catalog to keep the two consistent.
- Surfaced by a client after #1554 (initial/final balance valued_type split) shipped, which added two new untranslated labels alongside long-standing gaps on the move-type labels.

## Test plan
- [x] `msgfmt -c` validates the updated `ro.po` with no errors
- [x] `polib` parses the file (115 entries) with no errors
- [x] Verified against `l10n_ro_stock_account/i18n/ro.po` that every ported `msgstr` matches the existing approved translation for the same English label

🤖 Generated with [Claude Code](https://claude.com/claude-code)