### PR TITLE
[19.0][FIX] l10n_ro_message_spv: CIF lookup with/without RO prefix + multi-company isolation

### DIFF
--- a/l10n_ro_message_spv/README.rst
+++ b/l10n_ro_message_spv/README.rst
@@ -223,6 +223,24 @@ Configuration
 Changelog
 =========
 
+**19.0.2.11.0 (2026-08-19)**
+
+- The partner lookup by tax ID now accepts both spellings of the
+  Romanian CIF. ANAF sends the code sometimes with and sometimes without
+  the ``RO`` prefix, while the partner in Odoo may hold the other
+  variant; the lookup used to fail in that case and a duplicate
+  ``Unknown`` partner was created for a company already in the database.
+  Both variants are now searched, and the tax ID written on a newly
+  created partner is normalized without the prefix.
+- Multi-company isolation on SPV messages: ``Invoice``, ``Partner`` and
+  ``Attachment`` are company-checked, the downloaded ZIP is stored in
+  the message's company, the invoice is created explicitly in that
+  company, and the partner lookup/creation is restricted to the
+  message's company (or to partners shared between companies). The
+  ``Company`` field is shown in the list, form and search views,
+  together with a ``Company`` grouping, only for users with
+  multi-company rights.
+
 **19.0.2.9.1 (2026-08-13)**
 
 - Matching an SPV message to an invoice no longer leaves the invoice in

--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "19.0.2.10.0",
+    "version": "19.0.2.11.0",
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -3,6 +3,7 @@
 
 import io
 import logging
+import re
 import zipfile
 from base64 import b64decode
 
@@ -20,6 +21,7 @@ class MessageSPV(models.Model):
     _name = "l10n.ro.message.spv"
     _description = "Message SPV"
     _order = "date desc"
+    _check_company_auto = True
 
     name = fields.Char(string="Message ID")  # id
     cif = fields.Char()  # cif
@@ -44,8 +46,8 @@ class MessageSPV(models.Model):
 
     # campuri suplimentare
 
-    invoice_id = fields.Many2one("account.move", string="Invoice")
-    partner_id = fields.Many2one("res.partner", string="Partner")
+    invoice_id = fields.Many2one("account.move", string="Invoice", check_company=True)
+    partner_id = fields.Many2one("res.partner", string="Partner", check_company=True)
 
     # draft - starea initiala a mesajului descarcat din SPV
     # downloaded - fisierul a fost descarcat cu succes
@@ -64,11 +66,17 @@ class MessageSPV(models.Model):
     download_attempts = fields.Integer(default=0)
     last_download_date = fields.Date()
     file_name = fields.Char()
-    attachment_id = fields.Many2one("ir.attachment", string="Attachment")
+    attachment_id = fields.Many2one(
+        "ir.attachment", string="Attachment", check_company=True
+    )
     # The signed ANAF ZIP (attachment_id) is the only stored file. The XML
     # and the PDFs are derived from it on demand; these fields only expose
     # what was materialized on the invoice (the XML import source and the
     # embedded PDF preview).
+    # They are computed and not stored, so they carry no `check_company`:
+    # nothing is written through them, and their company consistency is
+    # already guaranteed by `invoice_id` (they can only point to attachments
+    # of that invoice, which is itself company-checked).
     attachment_xml_id = fields.Many2one(
         "ir.attachment", string="XML", compute="_compute_derived_attachments"
     )
@@ -238,6 +246,7 @@ class MessageSPV(models.Model):
                 "name": file_name,
                 "raw": response["content"],
                 "mimetype": "application/zip",
+                "company_id": message.company_id.id,
             }
             attachment = self.env["ir.attachment"].sudo().create(attachment_value)
 
@@ -532,6 +541,7 @@ class MessageSPV(models.Model):
                 "partner_id": message.partner_id.id,
                 "l10n_ro_edi_download": message.name,
                 "l10n_ro_edi_transaction": message.request_id,
+                "company_id": message.company_id.id,
             }
             if "extract_state" in move_obj._fields:
                 invoice_values["extract_state"] = "no_extract_requested"
@@ -716,16 +726,33 @@ class MessageSPV(models.Model):
         }
 
     def get_partner(self):
+        partner_obj = self.env["res.partner"]
         for message in self.filtered(lambda m: not m.partner_id):
             if message.cif:
-                domain = [("vat", "like", message.cif), ("is_company", "=", True)]
-                partner = self.env["res.partner"].search(domain, limit=1)
+                # The CIF may reach us with or without the "RO" prefix, while
+                # the partner in Odoo can hold the other spelling: try both.
+                cif_clean = re.sub(r"^RO", "", message.cif.strip().upper())
+                partner = partner_obj.browse()
+                for variant in (cif_clean, "RO" + cif_clean):
+                    partner = partner_obj.search(
+                        [
+                            ("vat", "=ilike", variant),
+                            ("is_company", "=", True),
+                            "|",
+                            ("company_id", "=", message.company_id.id),
+                            ("company_id", "=", False),
+                        ],
+                        limit=1,
+                    )
+                    if partner:
+                        break
                 if not partner:
-                    partner = self.env["res.partner"].create(
+                    partner = partner_obj.create(
                         {
                             "name": message.cif,
                             "vat": message.cif,
                             "is_company": True,
+                            "company_id": message.company_id.id,
                         }
                     )
                 message.write({"partner_id": partner.id})

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -95,28 +95,45 @@ class ResCompany(models.Model):
     def _l10n_ro_get_partner_from_cif(self, cif):
         self.ensure_one()
         company_id = self.id
-        domain = [
-            ("vat", "like", cif),
-            ("is_company", "=", True),
+
+        # ANAF sends the CIF sometimes with and sometimes without the "RO"
+        # prefix, while the partner stored in Odoo may hold the other variant.
+        # Search both spellings, otherwise the lookup fails and a duplicate
+        # "Unknown" partner is created for an already known company.
+        cif_clean = re.sub(r"^RO", "", (cif or "").strip().upper())
+        cif_variants = [cif_clean, "RO" + cif_clean]
+        # Multi-company: only partners of this company (or shared ones) may
+        # be matched, so that data does not leak between companies.
+        company_domain = [
+            "|",
             ("company_id", "=", company_id),
+            ("company_id", "=", False),
         ]
-        partner = self.env["res.partner"].search(domain, limit=1)
+
+        def _search(extra_domain):
+            for variant in cif_variants:
+                result = self.env["res.partner"].search(
+                    [("vat", "=ilike", variant)] + extra_domain, limit=1
+                )
+                if result:
+                    return result
+            return self.env["res.partner"]
+
+        partner = _search([("is_company", "=", True), ("company_id", "=", company_id)])
         if not partner:
-            domain = [("vat", "like", cif), ("is_company", "=", True)]
-            partner = self.env["res.partner"].search(domain, limit=1)
+            partner = _search([("is_company", "=", True)] + company_domain)
         if not partner:
-            domain = [("vat", "like", cif)]
-            partner = self.env["res.partner"].search(domain, limit=1)
+            partner = _search(company_domain)
         if not partner:
             partner = self.env["res.partner"].create(
                 {
                     "name": "Unknown",
-                    "vat": cif,
                     "company_id": company_id,
                     "country_id": self.env.ref("base.ro").id,
                     "is_company": True,
                 }
             )
+            partner.write({"vat": cif_clean})
         return partner
 
     def _l10n_ro_download_message_spv(self, no_days=0):

--- a/l10n_ro_message_spv/readme/HISTORY.md
+++ b/l10n_ro_message_spv/readme/HISTORY.md
@@ -1,3 +1,20 @@
+**19.0.2.11.0 (2026-08-19)**
+
+- The partner lookup by tax ID now accepts both spellings of the Romanian
+  CIF. ANAF sends the code sometimes with and sometimes without the `RO`
+  prefix, while the partner in Odoo may hold the other variant; the
+  lookup used to fail in that case and a duplicate `Unknown` partner was
+  created for a company already in the database. Both variants are now
+  searched, and the tax ID written on a newly created partner is
+  normalized without the prefix.
+- Multi-company isolation on SPV messages: `Invoice`, `Partner` and
+  `Attachment` are company-checked, the downloaded ZIP is stored in the
+  message's company, the invoice is created explicitly in that company,
+  and the partner lookup/creation is restricted to the message's company
+  (or to partners shared between companies). The `Company` field is shown
+  in the list, form and search views, together with a `Company` grouping,
+  only for users with multi-company rights.
+
 **19.0.2.9.1 (2026-08-13)**
 
 - Matching an SPV message to an invoice no longer leaves the invoice in

--- a/l10n_ro_message_spv/static/description/index.html
+++ b/l10n_ro_message_spv/static/description/index.html
@@ -599,6 +599,24 @@ XML-ul a fost validat de sistemul ANAF.</li>
 </div>
 <div class="section" id="changelog">
 <h4><a class="toc-backref" href="#toc-entry-2">Changelog</a></h4>
+<p><strong>19.0.2.11.0 (2026-08-19)</strong></p>
+<ul class="simple">
+<li>The partner lookup by tax ID now accepts both spellings of the
+Romanian CIF. ANAF sends the code sometimes with and sometimes without
+the <tt class="docutils literal">RO</tt> prefix, while the partner in Odoo may hold the other
+variant; the lookup used to fail in that case and a duplicate
+<tt class="docutils literal">Unknown</tt> partner was created for a company already in the database.
+Both variants are now searched, and the tax ID written on a newly
+created partner is normalized without the prefix.</li>
+<li>Multi-company isolation on SPV messages: <tt class="docutils literal">Invoice</tt>, <tt class="docutils literal">Partner</tt> and
+<tt class="docutils literal">Attachment</tt> are company-checked, the downloaded ZIP is stored in
+the message’s company, the invoice is created explicitly in that
+company, and the partner lookup/creation is restricted to the
+message’s company (or to partners shared between companies). The
+<tt class="docutils literal">Company</tt> field is shown in the list, form and search views,
+together with a <tt class="docutils literal">Company</tt> grouping, only for users with
+multi-company rights.</li>
+</ul>
 <p><strong>19.0.2.9.1 (2026-08-13)</strong></p>
 <ul class="simple">
 <li>Matching an SPV message to an invoice no longer leaves the invoice in

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -1317,3 +1317,184 @@ class TestMessageSPV(TestMessageSPV):
         self.assertFalse(manual_line._l10n_ro_is_spv_imported_line())
         self.assertEqual(manual_line.name, "Produs adaugat manual")
         self.assertEqual(manual_line.price_unit, 55.0)
+
+    # ------------------------------------------------------------------
+    # CIF lookup with / without the "RO" prefix
+    # ------------------------------------------------------------------
+
+    def test_get_partner_from_cif_ro_prefix_variants(self):
+        """ANAF sends the CIF with or without the RO prefix: both must match
+        the same partner, instead of creating a duplicate "Unknown"."""
+        company = self.env.company
+        # the partner holds "RO20603502", the message brings the bare number
+        self.assertEqual(company._l10n_ro_get_partner_from_cif("20603502"), self.vendor)
+        # ... and the other way around, the same partner is found
+        self.assertEqual(
+            company._l10n_ro_get_partner_from_cif("RO20603502"), self.vendor
+        )
+        # the partner holds the bare number, the message brings "RO"
+        no_prefix_partner = self.env["res.partner"].create(
+            {
+                "name": "Furnizor fara prefix",
+                "vat": "12345674",
+                "is_company": True,
+                "country_id": self.env.ref("base.ro").id,
+            }
+        )
+        self.assertEqual(no_prefix_partner.vat, "12345674")
+        self.assertEqual(
+            company._l10n_ro_get_partner_from_cif("RO12345674"), no_prefix_partner
+        )
+        self.assertEqual(
+            company._l10n_ro_get_partner_from_cif("12345674"), no_prefix_partner
+        )
+
+    def test_get_partner_from_cif_creates_normalized_partner(self):
+        """An unknown CIF creates a single partner, with the CIF normalized
+        without the RO prefix."""
+        company = self.env.company
+        partner = company._l10n_ro_get_partner_from_cif("RO9999997")
+        self.assertEqual(partner.name, "Unknown")
+        self.assertEqual(partner.vat, "9999997")
+        self.assertEqual(partner.company_id, company)
+        # the second call, with the other spelling, reuses the same partner
+        self.assertEqual(company._l10n_ro_get_partner_from_cif("9999997"), partner)
+
+    def test_message_get_partner_ro_prefix_variants(self):
+        """get_partner on the message follows the same rule as the company
+        helper."""
+        message = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_CIF_VARIANT",
+                "cif": "20603502",
+                "company_id": self.env.company.id,
+            }
+        )
+        message.get_partner()
+        self.assertEqual(message.partner_id, self.vendor)
+
+    # ------------------------------------------------------------------
+    # Multi-company isolation
+    # ------------------------------------------------------------------
+
+    def _create_other_company(self, name="Alta companie SPV"):
+        return self.env["res.company"].create(
+            {"name": name, "country_id": self.env.ref("base.ro").id}
+        )
+
+    def test_multi_company_partner_isolation(self):
+        """A partner belonging to another company must not be reused: neither
+        by get_partner, nor by the company helper."""
+        other_company = self._create_other_company()
+        foreign_partner = self.env["res.partner"].create(
+            {
+                "name": "Furnizor alta companie",
+                "vat": "RO12345674",
+                "is_company": True,
+                "country_id": self.env.ref("base.ro").id,
+                "company_id": other_company.id,
+            }
+        )
+        message = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_MULTICOMPANY",
+                "cif": "12345674",
+                "company_id": self.env.company.id,
+            }
+        )
+        message.get_partner()
+        self.assertTrue(message.partner_id)
+        self.assertNotEqual(message.partner_id, foreign_partner)
+        self.assertEqual(message.partner_id.company_id, self.env.company)
+
+        foreign_partner_2 = self.env["res.partner"].create(
+            {
+                "name": "Alt furnizor alta companie",
+                "vat": "RO9999997",
+                "is_company": True,
+                "country_id": self.env.ref("base.ro").id,
+                "company_id": other_company.id,
+            }
+        )
+        partner = self.env.company._l10n_ro_get_partner_from_cif("9999997")
+        self.assertNotEqual(partner, foreign_partner_2)
+        self.assertEqual(partner.name, "Unknown")
+        self.assertEqual(partner.company_id, self.env.company)
+
+    def test_multi_company_check_company_on_attachment(self):
+        """The stored ZIP cannot belong to a company other than the
+        message's one."""
+        other_company = self._create_other_company("Companie atasament SPV")
+        message = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_MC_ATTACHMENT",
+                "company_id": self.env.company.id,
+            }
+        )
+        foreign_attachment = self.env["ir.attachment"].create(
+            {
+                "name": "foreign.zip",
+                "raw": b"foreign",
+                "mimetype": "application/zip",
+                "company_id": other_company.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            message.attachment_id = foreign_attachment
+        # an attachment of the same company (or a shared one) is accepted
+        own_attachment = self.env["ir.attachment"].create(
+            {
+                "name": "own.zip",
+                "raw": b"own",
+                "mimetype": "application/zip",
+                "company_id": self.env.company.id,
+            }
+        )
+        message.attachment_id = own_attachment
+        self.assertEqual(message.attachment_id, own_attachment)
+
+    def test_multi_company_check_company_on_partner(self):
+        """partner_id is company-checked as well."""
+        other_company = self._create_other_company("Companie partener SPV")
+        message = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "MSG_MC_INVOICE",
+                "company_id": self.env.company.id,
+            }
+        )
+        foreign_partner = self.env["res.partner"].create(
+            {
+                "name": "Partener alta companie",
+                "is_company": True,
+                "company_id": other_company.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            message.partner_id = foreign_partner
+
+    def test_download_stores_zip_in_message_company(self):
+        """The downloaded ZIP and the created bill belong to the message's
+        company."""
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "3006372781",
+                "request_id": "5004111924",
+                "company_id": self.env.company.id,
+                "message_type": "in_invoice",
+                "cif": "8486152",
+            }
+        )
+        file_invoice = file_path("l10n_ro_message_spv/tests/invoice.zip")
+        with open(file_invoice, "rb") as zip_file:
+            anaf_messages = {"content": zip_file.read()}
+        with patch(
+            "odoo.addons.l10n_ro_message_spv.models.ciusro_document.make_efactura_request",
+            return_value=anaf_messages,
+        ):
+            message_spv.download_from_spv()
+
+        self.assertEqual(message_spv.attachment_id.company_id, self.env.company)
+
+        message_spv.create_invoice()
+        self.assertTrue(message_spv.invoice_id)
+        self.assertEqual(message_spv.invoice_id.company_id, self.env.company)

--- a/l10n_ro_message_spv/views/message_spv_view.xml
+++ b/l10n_ro_message_spv/views/message_spv_view.xml
@@ -36,7 +36,7 @@
 
                 <field name="partner_id" />
                 <field name="request_id" />
-                <field name="company_id" invisible="1" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <field name="currency_id" invisible="1" />
                 <field
                     name="amount"
@@ -120,7 +120,10 @@
                             <field name="request_id" />
                         </group>
                         <group string="Reference">
-                            <field name="company_id" invisible="1" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                            />
                             <field name="partner_id" />
                             <field name="ref" />
                             <field name="invoice_date" />
@@ -163,7 +166,7 @@
                 <field name="invoice_date" />
                 <field name="partner_id" />
                 <field name="request_id" />
-                <field name="company_id" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <field name="invoice_id" />
                 <field name="state" />
                 <group>
@@ -216,6 +219,12 @@
                         name="group_partner_id"
                         string="Partner"
                         context="{'group_by': 'partner_id'}"
+                    />
+                    <filter
+                        name="group_company_id"
+                        string="Company"
+                        context="{'group_by': 'company_id'}"
+                        groups="base.group_multi_company"
                     />
                 </group>
             </search>


### PR DESCRIPTION
## Summary
Backport of two gaps found on 18.0 and never ported to 19.0 (ticket #9287):

- Partner lookup by CIF now normalizes the `RO` prefix and tries both spellings, instead of creating a duplicate "Unknown" partner when the message and the partner store the code differently.
- Multi-company isolation: `check_company` on the stored `Many2one` fields, `company_id` on the downloaded ZIP and on the created bill, company-filtered partner lookup/creation, and the Company field/grouping shown only to multi-company users.

The computed attachment fields (XML / ANAF PDF / embedded PDF) get no `check_company`: since the ZIP-only refactor they are derived on demand from the invoice, whose company is already checked.

## Test plan
- [x] New tests added in `tests/test_message_spv.py` covering CIF-prefix normalization and multi-company isolation
- [x] Verified the branch contains only this module's files against `oca/19.0` (`git diff --stat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)