### PR TITLE
[19.0][FIX] l10n_ro_stock_report: printed FINAL row on all-locations report

### DIFF
--- a/l10n_ro_stock_report/README.rst
+++ b/l10n_ro_stock_report/README.rst
@@ -54,6 +54,28 @@ To install this module, you need to:
 Changelog
 =========
 
+19.0.2.9.0
+----------
+
+- Fix the "Toate locațiile" (all-locations) storage sheet report: the
+  printed FINAL row recomputed a running total from the individual
+  in/out detail lines instead of using the already-correct
+  ``quantity_final``/``amount_final`` stored on the FINAL line. The
+  ``t-if`` meant to branch on the FINAL row
+  (``product!=line_product.product_id``) is always false, since the
+  lines it iterates are already filtered to a single product, so every
+  row, FINAL included, went through the running-sum branch instead.
+  Ported from the 18.0 fix, where a manual correction layer with no
+  valued type was silently dropped from the in/out detail queries and so
+  was missing from the running total while still counted in the
+  correctly-computed final sum. The in/out queries were rewritten for
+  19.0 (stock.valuation.layer removed) and no longer have that specific
+  exclusion, but the template still recomputes instead of trusting the
+  stored final value, which stays fragile to any future gap between the
+  detail and final queries. The single-product report
+  (``report_storage_sheet``) was not affected, it already reads the
+  final line separately.
+
 19.0.2.6.0
 ----------
 

--- a/l10n_ro_stock_report/__manifest__.py
+++ b/l10n_ro_stock_report/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "Romania - Stock Report (Fișă Magazie)",
     "license": "AGPL-3",
-    "version": "19.0.2.8.0",
+    "version": "19.0.2.9.0",
     "countries": ["ro"],
     "author": "Terrabit,NextERP Romania,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",

--- a/l10n_ro_stock_report/readme/HISTORY.md
+++ b/l10n_ro_stock_report/readme/HISTORY.md
@@ -1,3 +1,22 @@
+## 19.0.2.9.0
+
+- Fix the "Toate locațiile" (all-locations) storage sheet report: the printed
+  FINAL row recomputed a running total from the individual in/out detail
+  lines instead of using the already-correct `quantity_final`/`amount_final`
+  stored on the FINAL line. The `t-if` meant to branch on the FINAL row
+  (`product!=line_product.product_id`) is always false, since the lines it
+  iterates are already filtered to a single product, so every row, FINAL
+  included, went through the running-sum branch instead. Ported from the
+  18.0 fix, where a manual correction layer with no valued type was silently
+  dropped from the in/out detail queries and so was missing from the running
+  total while still counted in the correctly-computed final sum. The
+  in/out queries were rewritten for 19.0 (stock.valuation.layer removed) and
+  no longer have that specific exclusion, but the template still recomputes
+  instead of trusting the stored final value, which stays fragile to any
+  future gap between the detail and final queries. The single-product report
+  (`report_storage_sheet`) was not affected, it already reads the final line
+  separately.
+
 ## 19.0.2.6.0
 
 - Give the opening and closing balance rows a valued type of their own,

--- a/l10n_ro_stock_report/report/stock_report_template.xml
+++ b/l10n_ro_stock_report/report/stock_report_template.xml
@@ -365,7 +365,7 @@
                                 <t t-set="quantity" t-value="0" />
                                 <t t-set="amount" t-value="0" />
                                 <t t-foreach="prod_acc_lines" t-as="line_product">
-                                    <t t-if="product!=line_product.product_id">
+                                    <t t-if="line_product.reference == 'FINAL'">
                                         <div>
                                             <span>
                                                 <strong

--- a/l10n_ro_stock_report/static/description/index.html
+++ b/l10n_ro_stock_report/static/description/index.html
@@ -381,15 +381,16 @@ ul.auto-toc {
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="toc-entry-1">Installation</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-2">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-3">19.0.2.6.0</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-4">19.0.2.4.1</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-3">19.0.2.9.0</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-4">19.0.2.6.0</a></li>
+<li><a class="reference internal" href="#section-3" id="toc-entry-5">19.0.2.4.1</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-6">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-7">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-8">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-9">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -409,7 +410,30 @@ ul.auto-toc {
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-2">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-3">19.0.2.6.0</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-3">19.0.2.9.0</a></h3>
+<ul class="simple">
+<li>Fix the “Toate locațiile” (all-locations) storage sheet report: the
+printed FINAL row recomputed a running total from the individual
+in/out detail lines instead of using the already-correct
+<tt class="docutils literal">quantity_final</tt>/<tt class="docutils literal">amount_final</tt> stored on the FINAL line. The
+<tt class="docutils literal"><span class="pre">t-if</span></tt> meant to branch on the FINAL row
+(<tt class="docutils literal"><span class="pre">product!=line_product.product_id</span></tt>) is always false, since the
+lines it iterates are already filtered to a single product, so every
+row, FINAL included, went through the running-sum branch instead.
+Ported from the 18.0 fix, where a manual correction layer with no
+valued type was silently dropped from the in/out detail queries and so
+was missing from the running total while still counted in the
+correctly-computed final sum. The in/out queries were rewritten for
+19.0 (stock.valuation.layer removed) and no longer have that specific
+exclusion, but the template still recomputes instead of trusting the
+stored final value, which stays fragile to any future gap between the
+detail and final queries. The single-product report
+(<tt class="docutils literal">report_storage_sheet</tt>) was not affected, it already reads the
+final line separately.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-4">19.0.2.6.0</a></h3>
 <ul class="simple">
 <li>Give the opening and closing balance rows a valued type of their own,
 <tt class="docutils literal">initial</tt> and <tt class="docutils literal">final</tt>. This changes the behaviour deliberately
@@ -427,8 +451,8 @@ against it. Typing the balances keeps them legible as balances and
 leaves the empty-type bucket to mean only what it says.</li>
 </ul>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-4">19.0.2.4.1</a></h3>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-5">19.0.2.4.1</a></h3>
 <ul class="simple">
 <li>Fix the storage sheet no longer splitting by valued type. Up to 18.0
 the valued type of a line came from the valuation layer
@@ -444,7 +468,7 @@ type, as in 18.0, since a balance aggregates several move types.</li>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-romania/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -452,16 +476,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-6">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-7">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Authors</a></h3>
 <ul class="simple">
 <li>Terrabit</li>
 <li>NextERP Romania</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-8">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-9">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.terrabit.ro">Terrabit</a>:<ul>
 <li>Dorin Hongu &lt;<a class="reference external" href="mailto:dhongu&#64;gmail.com">dhongu&#64;gmail.com</a>&gt;</li>
@@ -478,7 +502,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 technical issues.</p>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
## Summary
- Port of #1571 (18.0) to 19.0.
- The "all locations" storage sheet report (`report_storage_sheet_all`) prints the FINAL row by recomputing a running total from the individual in/out detail lines instead of reading the already-correct `quantity_final`/`amount_final` stored on the FINAL line itself.
- The `t-if` meant to single out the FINAL row (`product!=line_product.product_id`) can never be true, since the lines it iterates are already filtered to a single product — so every row, FINAL included, went through the running-sum branch.
- On 18.0 this was confirmed to actually diverge: a manual correction valuation layer with no `l10n_ro_valued_type` set was silently excluded from the in/out detail queries (a `!= 'reception_return'` comparison evaluates to `NULL`, not `TRUE`, for a `NULL` value), so the on-screen pivot view (reading the stored field directly) matched the balance while the printed report did not.
- The in/out queries were rewritten for 19.0 (`stock.valuation.layer` was removed, valuation now lives on `stock.move`) and no longer have that specific NULL-comparison gap, so this is a defensive/latent-bug fix here rather than a confirmed-reproduced one — the template still shouldn't recompute a value it already has correctly, and staying correct-by-construction here doesn't depend on the in/out queries never developing a similar gap again.
- The single-product report (`report_storage_sheet`) is unaffected — it already isolates and reads the FINAL line separately via a dedicated `final` variable.

## Test plan
- [x] Confirmed the same always-false `t-if` pattern exists in the 19.0 template, structurally identical to 18.0.
- [x] Confirmed the single-product report's loop already excludes `INITIAL`/`FINAL` (`prod_acc_lines.filtered(lambda l: l.reference not in ['INITIAL','FINAL'])`), so it needs no change.
- [ ] Not reproduced live on a 19.0 instance (no manual-correction-layer scenario at hand there) — would appreciate a maintainer/CI run of the module's existing test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)