### PR TITLE
18.0-l10n_ro_dvi: fix tax base reporting on VAT price difference

### DIFF
--- a/l10n_ro_dvi/models/l10n_ro_account_dvi.py
+++ b/l10n_ro_dvi/models/l10n_ro_account_dvi.py
@@ -228,11 +228,20 @@ class AccountInvoiceDVI(models.Model):
             tags = self.tax_id.invoice_repartition_line_ids.filtered(
                 lambda m: m.repartition_type == "tax"
             )[0]
+            base_repartition_line = self.tax_id.invoice_repartition_line_ids.filtered(
+                lambda m: m.repartition_type == "base"
+            )[0]
+            if self.company_id.account_cash_basis_base_account_id:
+                base_account_id = self.company_id.account_cash_basis_base_account_id.id
+            else:
+                base_account_id = tags.account_id.id
+            base_value = round(amount * 100 / self.tax_id.amount, 2)
             vals = {
                 "ref": "VAT Price Difference " + self.name,
                 "journal_id": self.journal_id.id,
                 "move_type": "entry",
                 "date": self.date,
+                "is_storno": True if amount < 0 else False,
                 "line_ids": [
                     (
                         0,
@@ -242,9 +251,10 @@ class AccountInvoiceDVI(models.Model):
                             if amount > 0
                             else tags.account_id.id,
                             "currency_id": self.currency_id.id,
-                            "debit": amount if amount > 0 else 0.0,
-                            "credit": -amount if amount < 0 else 0.0,
+                            "debit": amount,
+                            "credit": 0.0,
                             "amount_currency": amount,
+                            "balance": amount,
                             "tax_tag_ids": tags.tag_ids,
                         },
                     ),
@@ -254,9 +264,39 @@ class AccountInvoiceDVI(models.Model):
                         {
                             "account_id": account2,
                             "currency_id": self.currency_id.id,
-                            "debit": -amount if amount < 0 else 0.0,
-                            "credit": amount if amount > 0 else 0.0,
+                            "debit": 0.0,
+                            "credit": amount,
                             "amount_currency": -amount,
+                            "balance": -amount,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": _("BASE VAT Price Difference"),
+                            "account_id": base_account_id,
+                            "currency_id": self.currency_id.id,
+                            "debit": base_value,
+                            "credit": 0.0,
+                            "amount_currency": base_value,
+                            "balance": base_value,
+                            "tax_base_amount": base_value,
+                            "tax_tag_ids": base_repartition_line.tag_ids,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": _("BASE VAT Price Difference - offset"),
+                            "account_id": base_account_id,
+                            "currency_id": self.currency_id.id,
+                            "debit": -base_value,
+                            "credit": 0.0,
+                            "amount_currency": -base_value,
+                            "balance": -base_value,
+                            "is_refund": True,
                         },
                     ),
                 ],

--- a/l10n_ro_dvi/tests/test_dvi.py
+++ b/l10n_ro_dvi/tests/test_dvi.py
@@ -154,16 +154,42 @@ class TestDVI(TestStockCommon2):
         dvi.journal_id = self.journal_id
         dvi.customs_duty_value = 100
         dvi.customs_commission_value = 50
-        dvi.vat_price_difference = 10
+        dvi.vat_price_difference = 10  # positive amount
         dvi.vat_price_difference_product_id = self.vat_product_id
-        dvi.vat_price_difference = 10
         dvi = dvi.save()
         dvi.button_post()
-        for line in dvi.vat_price_difference_move_id.line_ids:
+
+        # VAT price diffference DVI positive amount
+        base_lines = dvi.vat_price_difference_move_id.line_ids.filtered(
+            lambda line: line.name and "BASE VAT Price Difference" in line.name
+        )
+        main_lines = dvi.vat_price_difference_move_id.line_ids - base_lines
+
+        self.assertEqual(len(base_lines), 2)
+        self.assertAlmostEqual(
+            sum(base_lines.mapped("debit")), sum(base_lines.mapped("credit"))
+        )
+
+        # Expected main_lines:
+        # Debit			Credit			Tax Grids
+        # 10.00 lei		0.00 lei		+24 - VAT
+        # 0.00 lei		10.00 lei
+        for line in main_lines:
             if line.account_id.id == self.account_expense.id:
                 self.assertEqual(line.debit, 10)
             else:
                 self.assertEqual(line.credit, 10)
+
+        # Expected base_lines:
+        # Debit			        Credit			    Tax Grids
+        # positive_amount		    0.00 lei		    +24 - TAX BASE
+        # 0.00 lei                positive_amount
+        for line in base_lines:
+            if line.tax_tag_ids:
+                self.assertTrue(line.debit > 0)
+            elif not line.tax_tag_ids:
+                self.assertTrue(line.credit > 0)
+
         # pentru valoare negativa
         self.create_po()
         self.create_invoice()
@@ -178,18 +204,44 @@ class TestDVI(TestStockCommon2):
         dvi.journal_id = self.journal_id
         dvi.customs_duty_value = 100
         dvi.customs_commission_value = 50
-        dvi.vat_price_difference = -10
+        dvi.vat_price_difference = -10  # negative amount
         dvi.vat_price_difference_product_id = self.vat_product_id
         dvi = dvi.save()
         dvi.button_post()
-        for line in dvi.vat_price_difference_move_id.line_ids:
+
+        # VAT price diffference DVI negative amount
+        base_lines = dvi.vat_price_difference_move_id.line_ids.filtered(
+            lambda line: line.name and "BASE VAT Price Difference" in line.name
+        )
+        main_lines = dvi.vat_price_difference_move_id.line_ids - base_lines
+
+        self.assertEqual(len(base_lines), 2)
+        self.assertAlmostEqual(
+            sum(base_lines.mapped("debit")), sum(base_lines.mapped("credit"))
+        )
+
+        # Expected main_lines:
+        # Debit			Credit			Tax Grids
+        # -10.00 lei		0.00 lei		+24 - VAT
+        # 0.00 lei		-10.00 lei
+        for line in main_lines:
             tags = tax_id.invoice_repartition_line_ids.filtered(
                 lambda m: m.repartition_type == "tax"
             )[0]
             if line.account_id.id == tags.account_id.id:
-                self.assertEqual(line.credit, 10)
+                self.assertEqual(line.debit, -10)
             else:
-                self.assertEqual(line.debit, 10)
+                self.assertEqual(line.credit, -10)
+
+        # Expected base_lines:
+        # Debit			        Credit			    Tax Grids
+        # negative_amount		    0.00 lei		    +24 - TAX BASE
+        # 0.00 lei                negative_amount
+        for line in base_lines:
+            if line.tax_tag_ids:
+                self.assertTrue(line.debit < 0)
+            elif not line.tax_tag_ids:
+                self.assertTrue(line.credit < 0)
 
         # cand da reverse move-ul trebuie sa fie in cancel
         self.create_po()


### PR DESCRIPTION
The DVI VAT price difference journal entry booked the VAT amount but never reported the corresponding tax base, so the base didn't show up on the tax return grid (only the VAT grid did).

- Compute base_value from amount/tax rate and add a base line + matching offset line, tagged with the base repartition line's tax tags and posted to account_cash_basis_base_account_id (or the tax account as fallback).
- Replace the amount>0/amount<0 debit/credit branching on the tax lines with signed debit + explicit balance, and set is_storno=True for negative amounts so these entries post as proper storno moves.
- Extend test_dvi.py to assert the base lines balance to zero and carry the correct sign/tag on both the positive and negative vat_price_difference scenarios.