### PR TITLE
19.0-l10n_ro_dvi: fix tax base reporting on VAT price difference

### DIFF
--- a/l10n_ro_dvi/models/__init__.py
+++ b/l10n_ro_dvi/models/__init__.py
@@ -1,4 +1,5 @@
 from . import account_invoice
+from . import account_tax
 from . import l10n_ro_account_dvi
 from . import res_company
 from . import stock_landed_cost

--- a/l10n_ro_dvi/models/account_tax.py
+++ b/l10n_ro_dvi/models/account_tax.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2026 NextERP Romania
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+from odoo.exceptions import UserError
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    def _l10n_ro_get_base_from_tax_amount(self, tax_amount, currency=None):
+        """Deduce the tax base underlying a known VAT amount.
+
+        Used when only the VAT amount is known (e.g. a VAT price
+        difference) and the corresponding base still has to be
+        reported on a tax grid. The rate is derived through
+        ``compute_all`` rather than reading ``self.amount`` directly,
+        so 'percent', 'division' and 'group' taxes are all handled
+        correctly.
+        """
+        self.ensure_one()
+        if self.amount_type == "fixed":
+            raise UserError(
+                self.env._(
+                    "Tax %s is a fixed amount tax; the VAT base cannot be"
+                    " deduced from a VAT amount.",
+                    self.display_name,
+                )
+            )
+        rate_values = self.compute_all(100.0)
+        tax_rate = rate_values["total_included"] - rate_values["total_excluded"]
+        if not tax_rate:
+            raise UserError(
+                self.env._(
+                    "Tax %s has no rate; the VAT base cannot be deduced.",
+                    self.display_name,
+                )
+            )
+        base_value = tax_amount * 100 / tax_rate
+        return currency.round(base_value) if currency else base_value

--- a/l10n_ro_dvi/models/l10n_ro_account_dvi.py
+++ b/l10n_ro_dvi/models/l10n_ro_account_dvi.py
@@ -234,11 +234,20 @@ class AccountInvoiceDVI(models.Model):
             tags = self.tax_id.invoice_repartition_line_ids.filtered(
                 lambda m: m.repartition_type == "tax"
             )[0]
+            base_repartition_line = self.tax_id.invoice_repartition_line_ids.filtered(
+                lambda m: m.repartition_type == "base"
+            )[0]
+            if self.company_id.account_cash_basis_base_account_id:
+                base_account_id = self.company_id.account_cash_basis_base_account_id.id
+            else:
+                base_account_id = tags.account_id.id
+            base_value = round(amount * 100 / self.tax_id.amount, 2)
             vals = {
                 "ref": "VAT Price Difference " + self.name,
                 "journal_id": self.journal_id.id,
                 "move_type": "entry",
                 "date": self.date,
+                "is_storno": True if amount < 0 else False,
                 "line_ids": [
                     (
                         0,
@@ -248,9 +257,10 @@ class AccountInvoiceDVI(models.Model):
                             if amount > 0
                             else tags.account_id.id,
                             "currency_id": self.currency_id.id,
-                            "debit": amount if amount > 0 else 0.0,
-                            "credit": -amount if amount < 0 else 0.0,
+                            "debit": amount,
+                            "credit": 0.0,
                             "amount_currency": amount,
+                            "balance": amount,
                             "tax_tag_ids": tags.tag_ids,
                         },
                     ),
@@ -260,9 +270,39 @@ class AccountInvoiceDVI(models.Model):
                         {
                             "account_id": account2,
                             "currency_id": self.currency_id.id,
-                            "debit": -amount if amount < 0 else 0.0,
-                            "credit": amount if amount > 0 else 0.0,
+                            "debit": 0.0,
+                            "credit": amount,
                             "amount_currency": -amount,
+                            "balance": -amount,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.env._("BASE VAT Price Difference"),
+                            "account_id": base_account_id,
+                            "currency_id": self.currency_id.id,
+                            "debit": base_value,
+                            "credit": 0.0,
+                            "amount_currency": base_value,
+                            "balance": base_value,
+                            "tax_base_amount": base_value,
+                            "tax_tag_ids": base_repartition_line.tag_ids,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.env._("BASE VAT Price Difference - offset"),
+                            "account_id": base_account_id,
+                            "currency_id": self.currency_id.id,
+                            "debit": -base_value,
+                            "credit": 0.0,
+                            "amount_currency": -base_value,
+                            "balance": -base_value,
+                            "is_refund": True,
                         },
                     ),
                 ],

--- a/l10n_ro_dvi/models/l10n_ro_account_dvi.py
+++ b/l10n_ro_dvi/models/l10n_ro_account_dvi.py
@@ -231,6 +231,9 @@ class AccountInvoiceDVI(models.Model):
             raise ValidationError((self.env._(msg), self.customs_duty_product_id.name))
         if account1 and account2:
             amount = self.vat_price_difference
+            # Always use invoice_repartition_line_ids, even when amount < 0:
+            # the negative balance already nets out correctly in the tax
+            # grid, so there's no need to switch to refund_repartition_line_ids.
             tags = self.tax_id.invoice_repartition_line_ids.filtered(
                 lambda m: m.repartition_type == "tax"
             )[0]
@@ -241,13 +244,15 @@ class AccountInvoiceDVI(models.Model):
                 base_account_id = self.company_id.account_cash_basis_base_account_id.id
             else:
                 base_account_id = tags.account_id.id
-            base_value = round(amount * 100 / self.tax_id.amount, 2)
+
+            base_value = self.tax_id._l10n_ro_get_base_from_tax_amount(
+                amount, currency=self.company_id.currency_id
+            )
             vals = {
                 "ref": "VAT Price Difference " + self.name,
                 "journal_id": self.journal_id.id,
                 "move_type": "entry",
                 "date": self.date,
-                "is_storno": True if amount < 0 else False,
                 "line_ids": [
                     (
                         0,
@@ -302,7 +307,6 @@ class AccountInvoiceDVI(models.Model):
                             "credit": 0.0,
                             "amount_currency": -base_value,
                             "balance": -base_value,
-                            "is_refund": True,
                         },
                     ),
                 ],
@@ -356,10 +360,7 @@ class AccountInvoiceDVI(models.Model):
 
         if self.vat_price_difference_product_id and self.vat_price_difference != 0:
             values_move = self.create_account_move_dvi()
-            move_object = self.env["account.move"]
-            if self.vat_price_difference < 0:
-                move_object = move_object.with_context(is_dvi_storno=True)
-            move = move_object.create(values_move)
+            move = self.env["account.move"].create(values_move)
 
             move.action_post()
             self.vat_price_difference_move_id = move.id

--- a/l10n_ro_dvi/tests/test_dvi.py
+++ b/l10n_ro_dvi/tests/test_dvi.py
@@ -207,16 +207,43 @@ class TestDVI(TestROStockCommon):
         dvi.journal_id = self.journal_id
         dvi.customs_duty_value = 100
         dvi.customs_commission_value = 50
-        dvi.vat_price_difference = 10
+        dvi.vat_price_difference = 10  # positive amount
         dvi.vat_price_difference_product_id = self.vat_product_id
         dvi.vat_price_difference = 10
         dvi = dvi.save()
         dvi.button_post()
-        for line in dvi.vat_price_difference_move_id.line_ids:
+
+        # VAT price diffference DVI positive amount
+        base_lines = dvi.vat_price_difference_move_id.line_ids.filtered(
+            lambda line: line.name and "BASE VAT Price Difference" in line.name
+        )
+        main_lines = dvi.vat_price_difference_move_id.line_ids - base_lines
+
+        self.assertEqual(len(base_lines), 2)
+        self.assertAlmostEqual(
+            sum(base_lines.mapped("debit")), sum(base_lines.mapped("credit"))
+        )
+
+        # Expected main_lines:
+        # Debit			Credit			Tax Grids
+        # 10.00 lei		0.00 lei		+24 - VAT
+        # 0.00 lei		10.00 lei
+        for line in main_lines:
             if line.account_id.id == self.account_expense.id:
                 self.assertEqual(line.debit, 10)
             else:
                 self.assertEqual(line.credit, 10)
+
+        # Expected base_lines:
+        # Debit			        Credit			    Tax Grids
+        # positive_amount		    0.00 lei		    +24 - TAX BASE
+        # negative_amount         0.00 lei
+        for line in base_lines:
+            if line.tax_tag_ids:
+                self.assertTrue(line.debit > 0)
+            elif not line.tax_tag_ids:
+                self.assertTrue(line.debit < 0)
+
         # pentru valoare negativa
         # self.create_po()
         # self.create_invoice()
@@ -231,18 +258,44 @@ class TestDVI(TestROStockCommon):
         dvi.journal_id = self.journal_id
         dvi.customs_duty_value = 100
         dvi.customs_commission_value = 50
-        dvi.vat_price_difference = -10
+        dvi.vat_price_difference = -10  # negative amount
         dvi.vat_price_difference_product_id = self.vat_product_id
         dvi = dvi.save()
         dvi.button_post()
-        for line in dvi.vat_price_difference_move_id.line_ids:
+
+        # VAT price diffference DVI negative amount
+        base_lines = dvi.vat_price_difference_move_id.line_ids.filtered(
+            lambda line: line.name and "BASE VAT Price Difference" in line.name
+        )
+        main_lines = dvi.vat_price_difference_move_id.line_ids - base_lines
+
+        self.assertEqual(len(base_lines), 2)
+        self.assertAlmostEqual(
+            sum(base_lines.mapped("debit")), sum(base_lines.mapped("credit"))
+        )
+
+        # Expected main_lines:
+        # Debit			Credit			Tax Grids
+        # -10.00 lei		0.00 lei		+24 - VAT
+        # 0.00 lei		-10.00 lei
+        for line in main_lines:
             tags = tax_id.invoice_repartition_line_ids.filtered(
                 lambda m: m.repartition_type == "tax"
             )[0]
             if line.account_id.id == tags.account_id.id:
-                self.assertEqual(line.credit, 10)
+                self.assertEqual(line.debit, -10)
             else:
-                self.assertEqual(line.debit, 10)
+                self.assertEqual(line.credit, -10)
+
+        # Expected base_lines:
+        # Debit			        Credit			    Tax Grids
+        # negative_amount		    0.00 lei		    +24 - TAX BASE
+        # positive_amount		    0.00 lei
+        for line in base_lines:
+            if line.tax_tag_ids:
+                self.assertTrue(line.debit < 0)
+            elif not line.tax_tag_ids:
+                self.assertTrue(line.debit > 0)
 
         # cand da reverse move-ul trebuie sa fie in cancel
         # self.create_po()

--- a/l10n_ro_dvi/tests/test_dvi.py
+++ b/l10n_ro_dvi/tests/test_dvi.py
@@ -209,7 +209,6 @@ class TestDVI(TestROStockCommon):
         dvi.customs_commission_value = 50
         dvi.vat_price_difference = 10  # positive amount
         dvi.vat_price_difference_product_id = self.vat_product_id
-        dvi.vat_price_difference = 10
         dvi = dvi.save()
         dvi.button_post()
 
@@ -218,10 +217,19 @@ class TestDVI(TestROStockCommon):
             lambda line: line.name and "BASE VAT Price Difference" in line.name
         )
         main_lines = dvi.vat_price_difference_move_id.line_ids - base_lines
+        base_repartition_line = tax_id.invoice_repartition_line_ids.filtered(
+            lambda m: m.repartition_type == "base"
+        )[0]
 
         self.assertEqual(len(base_lines), 2)
+        expected_base = 10 * 100 / tax_id.amount
+        self.assertEqual(sum(base_lines.mapped("balance")), 0)
         self.assertAlmostEqual(
-            sum(base_lines.mapped("debit")), sum(base_lines.mapped("credit"))
+            max(base_lines.mapped("balance")), expected_base, places=2
+        )
+        self.assertEqual(
+            base_lines.filtered("tax_tag_ids").tax_tag_ids,
+            base_repartition_line.tag_ids,
         )
 
         # Expected main_lines:
@@ -234,15 +242,16 @@ class TestDVI(TestROStockCommon):
             else:
                 self.assertEqual(line.credit, 10)
 
-        # Expected base_lines:
-        # Debit			        Credit			    Tax Grids
-        # positive_amount		    0.00 lei		    +24 - TAX BASE
-        # negative_amount         0.00 lei
+        # Expected base_lines (checked on balance, not debit/credit, since
+        # their sign display depends on company_id.account_storno):
+        # Balance			    Debit		        Credit          Tax Grids
+        # positive_amount		positive_amount		0.00 lei        +24 - TAX BASE
+        # negative_amount       negative_amount     0.00 lei
         for line in base_lines:
             if line.tax_tag_ids:
-                self.assertTrue(line.debit > 0)
-            elif not line.tax_tag_ids:
-                self.assertTrue(line.debit < 0)
+                self.assertTrue(line.balance > 0)
+            else:
+                self.assertTrue(line.balance < 0)
 
         # pentru valoare negativa
         # self.create_po()
@@ -268,34 +277,47 @@ class TestDVI(TestROStockCommon):
             lambda line: line.name and "BASE VAT Price Difference" in line.name
         )
         main_lines = dvi.vat_price_difference_move_id.line_ids - base_lines
+        base_repartition_line = tax_id.invoice_repartition_line_ids.filtered(
+            lambda m: m.repartition_type == "base"
+        )[0]
 
         self.assertEqual(len(base_lines), 2)
+        # magnitude is 10 regardless of sign, since the negative amount
+        # (-10) flips which of the two offsetting lines carries the tag
+        expected_base = 10 * 100 / tax_id.amount
+        self.assertEqual(sum(base_lines.mapped("balance")), 0)
         self.assertAlmostEqual(
-            sum(base_lines.mapped("debit")), sum(base_lines.mapped("credit"))
+            max(base_lines.mapped("balance")), expected_base, places=2
+        )
+        self.assertEqual(
+            base_lines.filtered("tax_tag_ids").tax_tag_ids,
+            base_repartition_line.tag_ids,
         )
 
-        # Expected main_lines:
-        # Debit			Credit			Tax Grids
-        # -10.00 lei		0.00 lei		+24 - VAT
-        # 0.00 lei		-10.00 lei
+        # Expected main_lines (checked on balance, not debit/credit, since
+        # their sign display depends on company_id.account_storno):
+        # Balance		    Debit			    Credit			Tax Grids
+        # -10.00 lei		-10.00 lei		    0.00 lei		+24 - VAT
+        # 10.00 lei		    0.00 lei		    -10.00 lei
         for line in main_lines:
             tags = tax_id.invoice_repartition_line_ids.filtered(
                 lambda m: m.repartition_type == "tax"
             )[0]
             if line.account_id.id == tags.account_id.id:
-                self.assertEqual(line.debit, -10)
+                self.assertEqual(line.balance, -10)
             else:
-                self.assertEqual(line.credit, -10)
+                self.assertEqual(line.balance, 10)
 
-        # Expected base_lines:
-        # Debit			        Credit			    Tax Grids
-        # negative_amount		    0.00 lei		    +24 - TAX BASE
-        # positive_amount		    0.00 lei
+        # Expected base_lines (checked on balance, not debit/credit, since
+        # their sign display depends on company_id.account_storno):
+        # Balance			    Debit			        Credit      Tax Grids
+        # negative_amount		negative_amount		    0.00 lei	+24 - TAX BASE
+        # positive_amount       positive_amount		    0.00 lei
         for line in base_lines:
             if line.tax_tag_ids:
-                self.assertTrue(line.debit < 0)
-            elif not line.tax_tag_ids:
-                self.assertTrue(line.debit > 0)
+                self.assertTrue(line.balance < 0)
+            else:
+                self.assertTrue(line.balance > 0)
 
         # cand da reverse move-ul trebuie sa fie in cancel
         # self.create_po()


### PR DESCRIPTION
The DVI VAT price difference journal entry booked the VAT amount but never reported the corresponding tax base, so the base didn't show up on the tax return grid (only the VAT grid did).

- Compute base_value from amount/tax rate and add a base line + matching offset line, tagged with the base repartition line's tax tags and posted to account_cash_basis_base_account_id (or the tax account as fallback).
- Replace the amount>0/amount<0 debit/credit branching on the tax lines with signed debit + explicit balance, and set is_storno=True for negative amounts so these entries post as proper storno moves.
- Extend test_dvi.py to assert the base lines balance to zero and carry the correct sign/tag on both the positive and negative vat_price_difference scenarios.