### PR TITLE
[19.0][FIX] - Comparatie corecta de cantitati

### DIFF
--- a/l10n_ro_stock_account/models/fifo/stock_move.py
+++ b/l10n_ro_stock_account/models/fifo/stock_move.py
@@ -315,7 +315,9 @@ class StockMove(models.Model):
             split_qty_for_move = sum(
                 vals.get("quantity", 0.0) for vals in fifo_split_vals_list[vals_before:]
             )
-            accounted_for = move.quantity + split_qty_for_move
+            accounted_for = move.product_uom._compute_quantity(
+                move.quantity + split_qty_for_move, move.product_id.uom_id, round=False
+            )
             if move.product_uom.compare(accounted_for, quantity_to_ship):
                 raise UserError(
                     self.env._(


### PR DESCRIPTION
Eroarea intampinata: Un produs are unitate de masura metrii (m). Pe stock move se foloseste in milimetrii (mm), Valorile din accounted_for si quantity_to_ship nu mai sunt egale din cauza lipsei de conversie pe unitatea de masura pe accounted_for.

Fix: accounted_for se calculeaza la unitatea de masura a produsului, la fel ca quantity_to_ship.