### PR TITLE
[ADD] review-gate: count approving reviews from any reviewer

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,47 @@
+name: review-gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Count approving reviews from any reviewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          REQUIRED: "2"
+        run: |
+          set -euo pipefail
+          # Latest review per user; an approval superseded by a later
+          # CHANGES_REQUESTED or dismissed by a push no longer counts.
+          approvers=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.state | IN("APPROVED", "CHANGES_REQUESTED", "DISMISSED"))]
+                  | group_by(.user.login)
+                  | map(max_by(.submitted_at))
+                  | map(select(.state == "APPROVED") | .user.login)
+                  | .[]' \
+            | { grep -vxF "$AUTHOR" || true; } | sort -u)
+          count=$(printf '%s' "$approvers" | grep -c . || true)
+          echo "Approvals: $count/$REQUIRED"
+          if [ -n "$approvers" ]; then
+            echo "$approvers" | sed 's/^/  - /'
+          fi
+          if [ "$count" -lt "$REQUIRED" ]; then
+            echo "::error::This PR needs $REQUIRED approving reviews, $count found." \
+              "Reviews from contributors without write access are counted here."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

The repository ruleset requires 2 approving reviews, but GitHub only counts
approvals from users with **write access** (the `core-maintainers`,
`local-romania-maintainers` and `board` teams). This is hard-coded behaviour —
there is no setting to change it. A review from a community contributor shows
up in the PR but does not move the counter, so in practice every PR needs two
of the same handful of people.

## What this does

`review-gate` counts **every** approving review, regardless of the reviewer's
access level, and reports it as a status check:

* latest review per user wins — an approval later replaced by
  `CHANGES_REQUESTED`, or dismissed by a push, stops counting;
* the PR author's own review is excluded;
* threshold is `REQUIRED: "2"` in the workflow.

Paired with lowering the native rule to **1 approving review**, the effective
policy becomes: *2 reviews total, at least 1 from a maintainer*. Community
reviews now count towards the second one.

`pull_request_target` is used so the workflow definition always comes from the
base branch; it never checks out or runs PR code, and the token is limited to
`pull-requests: read`.

## Before making the check required

The workflow must exist on a branch for its check to run on PRs targeting that
branch. It should be ported to the other active branches (16.0, 17.0, 18.0)
before `review-gate` is added to the ruleset as a required status check —
otherwise PRs to those branches sit in *Expected — waiting for status* forever.

## Known limitation

`OCA-git-bot` has `always` bypass on the ruleset, so `/ocabot merge` is not
subject to this check. The gate applies to the manual merge button.
