### PR TITLE
[ADD] review-gate: count approving reviews from any reviewer (18.0)

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,47 @@
+name: review-gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Count approving reviews from any reviewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          REQUIRED: "2"
+        run: |
+          set -euo pipefail
+          # Latest review per user; an approval superseded by a later
+          # CHANGES_REQUESTED or dismissed by a push no longer counts.
+          approvers=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" \
+            --jq '[.[] | select(.state | IN("APPROVED", "CHANGES_REQUESTED", "DISMISSED"))]
+                  | group_by(.user.login)
+                  | map(max_by(.submitted_at))
+                  | map(select(.state == "APPROVED") | .user.login)
+                  | .[]' \
+            | { grep -vxF "$AUTHOR" || true; } | sort -u)
+          count=$(printf '%s' "$approvers" | grep -c . || true)
+          echo "Approvals: $count/$REQUIRED"
+          if [ -n "$approvers" ]; then
+            echo "$approvers" | sed 's/^/  - /'
+          fi
+          if [ "$count" -lt "$REQUIRED" ]; then
+            echo "::error::This PR needs $REQUIRED approving reviews, $count found." \
+              "Reviews from contributors without write access are counted here."
+            exit 1
+          fi


### PR DESCRIPTION
Port of #1583 to 18.0.

A GitHub Actions workflow only runs for a pull request if the file exists on
the PR's **base** branch, so `review-gate` has to be present on every branch
that receives PRs before it can be made a required status check.

No changes to the workflow itself — identical to the file merged on 19.0.
