### PR TITLE
[19.0][FIX] l10n_ro_stock_report: count moves of archived internal locations

### DIFF
--- a/l10n_ro_stock_report/report/stock_report.py
+++ b/l10n_ro_stock_report/report/stock_report.py
@@ -75,8 +75,14 @@ class StorageSheet(models.TransientModel):
     @api.depends("sublocation", "location_id", "show_locations")
     def _compute_location_ids(self):
         if not self.location_id:
-            self.location_ids = self.env["stock.location"].search(
-                [("usage", "=", "internal")]
+            # Include archived locations: goods received in an internal location
+            # that was archived later (and moved on with zero-valued internal
+            # transfers) would otherwise be missing from the opening balance -
+            # the quantity would still be right, the value would not.
+            self.location_ids = (
+                self.env["stock.location"]
+                .with_context(active_test=False)
+                .search([("usage", "=", "internal")])
             )
         else:
             if self.sublocation:
@@ -88,6 +94,15 @@ class StorageSheet(models.TransientModel):
                 self.location_ids = self.location_id + children_location
             else:
                 self.location_ids = self.location_id
+
+    def _get_report_locations(self):
+        """Locations the report works on, archived ones included.
+
+        Reading a Many2many filters archived records out by default, so the
+        archived locations put in ``location_ids`` by the compute would be lost
+        again here without ``active_test=False``.
+        """
+        return self.with_context(active_test=False).location_ids
 
     def _get_report_base_filename(self):
         self.ensure_one()
@@ -108,7 +123,7 @@ class StorageSheet(models.TransientModel):
         return res
 
     def get_products_with_move_sql(self, product_list=False):
-        locations = self.location_ids
+        locations = self._get_report_locations()
 
         if product_list:
             query = """
@@ -164,8 +179,8 @@ class StorageSheet(models.TransientModel):
                         ("company_id", "=", self.company_id.id),
                         ("company_id", "=", False),
                         "|",
-                        ("location_id", "in", self.location_ids.ids),
-                        ("location_dest_id", "in", self.location_ids.ids),
+                        ("location_id", "in", self._get_report_locations().ids),
+                        ("location_dest_id", "in", self._get_report_locations().ids),
                     ]
                 )
                 .mapped("product_id")
@@ -209,11 +224,12 @@ class StorageSheet(models.TransientModel):
         datetime_to = datetime_to.replace(hour=23, minute=59, second=59)
         datetime_to = datetime_to.astimezone(pytz.utc)
 
+        report_locations = self._get_report_locations()
         if self.detailed_locations:
-            all_locations = self.with_context(active_test=False).location_ids
+            all_locations = report_locations
         else:
-            all_locations = self.location_id or self.location_ids[0]
-            locations = self.location_ids
+            all_locations = self.location_id or report_locations[0]
+            locations = report_locations
 
         for location in all_locations:
             if self.detailed_locations:

--- a/l10n_ro_stock_report/tests/test_report_stock.py
+++ b/l10n_ro_stock_report/tests/test_report_stock.py
@@ -318,6 +318,34 @@ class TestStockReport(TransactionCase):
         picking_type_out = self.env.ref("stock.picking_type_out")
         return self._create_simple_picking(picking_type_out, product, qty, date_dt)
 
+    def _create_internal_transfer(self, product, qty, src, dest, date_dt):
+        picking_type = self.env.ref("stock.picking_type_internal")
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": src.id,
+                "location_dest_id": dest.id,
+                "scheduled_date": date_dt,
+            }
+        )
+        self.env["stock.move"].create(
+            {
+                "product_id": product.id,
+                "product_uom": product.uom_id.id,
+                "product_uom_qty": qty,
+                "picking_id": picking.id,
+                "location_id": src.id,
+                "location_dest_id": dest.id,
+                "date": date_dt,
+                "company_id": self.env.company.id,
+            }
+        )
+        picking.action_confirm()
+        picking.button_validate()
+        for m in picking.move_ids:
+            m.date = date_dt
+        return picking
+
     def test_report_two_periods_quantities(self):
         """
         Scenario requested:
@@ -500,3 +528,58 @@ class TestStockReport(TransactionCase):
         )
         self.assertIn("initial", selection)
         self.assertIn("final", selection)
+
+    def test_report_counts_moves_of_archived_internal_locations(self):
+        """Goods received in an internal location that is archived afterwards
+        must stay in the report.
+
+        Real-world case: receipts went to an input location, the goods were
+        moved on to the main stock with internal transfers (zero-valued in
+        Odoo 19), then the input location was archived. Without the archived
+        locations in the set, the receipt is skipped and only the transfer is
+        counted as an entry: right quantity, missing value.
+        """
+        product = self.product_1
+        date_in = fields.Datetime.now() - timedelta(days=20)
+        receipt_type = self.env.ref("stock.picking_type_in")
+        receipt_type.default_location_dest_id = self.location_2
+        receipt = self._create_receipt(product, 10, date_in)
+        receipt_value = sum(receipt.move_ids.mapped("value"))
+        self.assertTrue(receipt_value, "The receipt must be valued")
+        self._create_internal_transfer(
+            product, 10, self.location_2, self.location, date_in
+        )
+        self.location_2.action_archive()
+        self.assertFalse(self.location_2.active)
+
+        # Period covering the receipt: the receipt line itself must be there.
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.date_from = (date_in - timedelta(days=1)).date()
+        wizard.date_to = (date_in + timedelta(days=1)).date()
+        wizard.product_ids.add(product)
+        wizard = wizard.save()
+        self.assertIn(self.location_2, wizard._get_report_locations())
+        wizard.do_compute_product()
+        lines = self.env["l10n.ro.stock.storage.sheet.line"].search(
+            [("report_id", "=", wizard.id), ("product_id", "=", product.id)]
+        )
+        self.assertIn(receipt.name, lines.mapped("reference"))
+
+        # Period after the receipt: the opening balance must carry its value.
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.date_from = (date_in + timedelta(days=5)).date()
+        wizard.date_to = (date_in + timedelta(days=6)).date()
+        wizard.product_ids.add(product)
+        wizard = wizard.save()
+        wizard.do_compute_product()
+        initial = self.env["l10n.ro.stock.storage.sheet.line"].search(
+            [
+                ("report_id", "=", wizard.id),
+                ("product_id", "=", product.id),
+                ("reference", "=", "INITIAL"),
+            ]
+        )
+        self.assertAlmostEqual(sum(initial.mapped("quantity_initial")), 10.0, places=2)
+        self.assertAlmostEqual(
+            sum(initial.mapped("amount_initial")), receipt_value, places=2
+        )


### PR DESCRIPTION
Fixes #1585

`_compute_location_ids` built the location set with `search([("usage", "=", "internal")])`, which honours `active_test`, so archived internal locations were excluded. Moves into or out of them were not counted at all.

Real-world case: receipts went to an internal input location, the goods were moved on with internal transfers (zero-valued in Odoo 19), then the input location was archived. The report skipped the receipt and counted the transfer as an entry with quantity and zero value. On a production database: opening balance on account 371 understated by 692,828 RON across 5,544 moves and 9,849 units, quantities exactly right.

Changes:
- build the set with `active_test=False`, as the sublocation branch already did;
- read it through `_get_report_locations()` everywhere the report uses it, because reading a Many2many filters archived records out again (the compute alone was not enough);
- test reproducing the scenario: receipt into a location archived afterwards, checked both in the period (receipt line present) and as opening balance (value carried).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
