### PR TITLE
[19.0][FIX] l10n_ro_stock_report: do not count internal transfers as input and output

### DIFF
--- a/l10n_ro_stock_report/report/stock_report.py
+++ b/l10n_ro_stock_report/report/stock_report.py
@@ -75,8 +75,14 @@ class StorageSheet(models.TransientModel):
     @api.depends("sublocation", "location_id", "show_locations")
     def _compute_location_ids(self):
         if not self.location_id:
-            self.location_ids = self.env["stock.location"].search(
-                [("usage", "=", "internal")]
+            # Include archived locations: goods received in an internal location
+            # that was archived later (and moved on with zero-valued internal
+            # transfers) would otherwise be missing from the opening balance -
+            # the quantity would still be right, the value would not.
+            self.location_ids = (
+                self.env["stock.location"]
+                .with_context(active_test=False)
+                .search([("usage", "=", "internal")])
             )
         else:
             if self.sublocation:
@@ -88,6 +94,15 @@ class StorageSheet(models.TransientModel):
                 self.location_ids = self.location_id + children_location
             else:
                 self.location_ids = self.location_id
+
+    def _get_report_locations(self):
+        """Locations the report works on, archived ones included.
+
+        Reading a Many2many filters archived records out by default, so the
+        archived locations put in ``location_ids`` by the compute would be lost
+        again here without ``active_test=False``.
+        """
+        return self.with_context(active_test=False).location_ids
 
     def _get_report_base_filename(self):
         self.ensure_one()
@@ -108,7 +123,7 @@ class StorageSheet(models.TransientModel):
         return res
 
     def get_products_with_move_sql(self, product_list=False):
-        locations = self.location_ids
+        locations = self._get_report_locations()
 
         if product_list:
             query = """
@@ -164,8 +179,8 @@ class StorageSheet(models.TransientModel):
                         ("company_id", "=", self.company_id.id),
                         ("company_id", "=", False),
                         "|",
-                        ("location_id", "in", self.location_ids.ids),
-                        ("location_dest_id", "in", self.location_ids.ids),
+                        ("location_id", "in", self._get_report_locations().ids),
+                        ("location_dest_id", "in", self._get_report_locations().ids),
                     ]
                 )
                 .mapped("product_id")
@@ -209,11 +224,12 @@ class StorageSheet(models.TransientModel):
         datetime_to = datetime_to.replace(hour=23, minute=59, second=59)
         datetime_to = datetime_to.astimezone(pytz.utc)
 
+        report_locations = self._get_report_locations()
         if self.detailed_locations:
-            all_locations = self.with_context(active_test=False).location_ids
+            all_locations = report_locations
         else:
-            all_locations = self.location_id or self.location_ids[0]
-            locations = self.location_ids
+            all_locations = self.location_id or report_locations[0]
+            locations = report_locations
 
         for location in all_locations:
             if self.detailed_locations:

--- a/l10n_ro_stock_report/report/stock_report.py
+++ b/l10n_ro_stock_report/report/stock_report.py
@@ -401,6 +401,14 @@ class StorageSheet(models.TransientModel):
         return sql
 
     def _get_sql_select_in(self):
+        # A move whose source AND destination are both in the reported set is an
+        # internal transfer for that set: neither an entry nor an exit. Without
+        # the exclusion it was counted once as input and once as output, which
+        # inflated both turnover columns by its value (transfers created by the
+        # relocation flows do carry a value). Balances were not affected.
+        # With detailed_locations the set holds one location, so transfers
+        # between two locations still show as exit from one and entry into the
+        # other.
         field, select, join, group = self._get_lot_fields()
 
         sql = f"""
@@ -444,6 +452,7 @@ class StorageSheet(models.TransientModel):
             ( %(all_products)s OR sm.product_id in %(product)s ) AND
             sm.date >= %(datetime_from)s AND sm.date <= %(datetime_to)s AND
             sm.location_dest_id in %(locations)s AND
+            sm.location_id not in %(locations)s AND
            (sm.l10n_ro_transfer_account_id IS NOT NULL
             OR sm.l10n_ro_account_id IS NOT NULL)
 
@@ -499,6 +508,7 @@ class StorageSheet(models.TransientModel):
             ( %(all_products)s OR sm.product_id in %(product)s ) AND
             sm.date >= %(datetime_from)s AND sm.date <= %(datetime_to)s AND
             sm.location_id in %(locations)s AND
+            sm.location_dest_id not in %(locations)s AND
             (sm.l10n_ro_account_id IS NOT NULL
              OR sm.l10n_ro_transfer_account_id IS NOT NULL)
 

--- a/l10n_ro_stock_report/tests/test_report_stock.py
+++ b/l10n_ro_stock_report/tests/test_report_stock.py
@@ -583,3 +583,68 @@ class TestStockReport(TransactionCase):
         self.assertAlmostEqual(
             sum(initial.mapped("amount_initial")), receipt_value, places=2
         )
+
+    def test_report_internal_transfer_not_counted_as_in_and_out(self):
+        """An internal transfer between two locations of the reported set is
+        neither an entry nor an exit for the set.
+
+        Without a location filter the set holds every internal location, so a
+        transfer matched both the input query (destination in set) and the
+        output query (source in set) and inflated both turnover columns by its
+        value. Per-location sheets (detailed_locations) must keep showing it as
+        exit from one location and entry into the other.
+        """
+        product = self.product_1
+        date_in = fields.Datetime.now() - timedelta(days=20)
+        receipt = self._create_receipt(product, 10, date_in)
+        receipt_value = sum(receipt.move_ids.mapped("value"))
+        self._create_internal_transfer(
+            product, 4, self.location, self.location_2, date_in
+        )
+        Line = self.env["l10n.ro.stock.storage.sheet.line"]
+
+        # Whole stock: only the receipt is an entry, nothing left the stock.
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.date_from = (date_in - timedelta(days=1)).date()
+        wizard.date_to = (date_in + timedelta(days=1)).date()
+        wizard.product_ids.add(product)
+        wizard = wizard.save()
+        wizard.do_compute_product()
+        lines = Line.search(
+            [("report_id", "=", wizard.id), ("product_id", "=", product.id)]
+        )
+        self.assertAlmostEqual(sum(lines.mapped("quantity_in")), 10.0, places=2)
+        self.assertAlmostEqual(sum(lines.mapped("amount_in")), receipt_value, places=2)
+        self.assertAlmostEqual(sum(lines.mapped("quantity_out")), 0.0, places=2)
+        self.assertAlmostEqual(sum(lines.mapped("amount_out")), 0.0, places=2)
+        final = lines.filtered(lambda line: line.reference == "FINAL")
+        self.assertAlmostEqual(sum(final.mapped("quantity_final")), 10.0, places=2)
+
+        # Per location: the transfer is an exit from one and an entry into the other.
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.date_from = (date_in - timedelta(days=1)).date()
+        wizard.date_to = (date_in + timedelta(days=1)).date()
+        wizard.location_id = self.location
+        wizard.sublocation = True
+        wizard.detailed_locations = True
+        wizard.product_ids.add(product)
+        wizard = wizard.save()
+        wizard.do_compute_product()
+        src = Line.search(
+            [
+                ("report_id", "=", wizard.id),
+                ("product_id", "=", product.id),
+                ("location_id", "=", self.location.id),
+            ]
+        )
+        dest = Line.search(
+            [
+                ("report_id", "=", wizard.id),
+                ("product_id", "=", product.id),
+                ("location_id", "=", self.location_2.id),
+            ]
+        )
+        self.assertAlmostEqual(sum(src.mapped("quantity_in")), 10.0, places=2)
+        self.assertAlmostEqual(sum(src.mapped("quantity_out")), 4.0, places=2)
+        self.assertAlmostEqual(sum(dest.mapped("quantity_in")), 4.0, places=2)
+        self.assertAlmostEqual(sum(dest.mapped("quantity_out")), 0.0, places=2)

--- a/l10n_ro_stock_report/tests/test_report_stock.py
+++ b/l10n_ro_stock_report/tests/test_report_stock.py
@@ -318,6 +318,34 @@ class TestStockReport(TransactionCase):
         picking_type_out = self.env.ref("stock.picking_type_out")
         return self._create_simple_picking(picking_type_out, product, qty, date_dt)
 
+    def _create_internal_transfer(self, product, qty, src, dest, date_dt):
+        picking_type = self.env.ref("stock.picking_type_internal")
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": src.id,
+                "location_dest_id": dest.id,
+                "scheduled_date": date_dt,
+            }
+        )
+        self.env["stock.move"].create(
+            {
+                "product_id": product.id,
+                "product_uom": product.uom_id.id,
+                "product_uom_qty": qty,
+                "picking_id": picking.id,
+                "location_id": src.id,
+                "location_dest_id": dest.id,
+                "date": date_dt,
+                "company_id": self.env.company.id,
+            }
+        )
+        picking.action_confirm()
+        picking.button_validate()
+        for m in picking.move_ids:
+            m.date = date_dt
+        return picking
+
     def test_report_two_periods_quantities(self):
         """
         Scenario requested:
@@ -500,3 +528,58 @@ class TestStockReport(TransactionCase):
         )
         self.assertIn("initial", selection)
         self.assertIn("final", selection)
+
+    def test_report_counts_moves_of_archived_internal_locations(self):
+        """Goods received in an internal location that is archived afterwards
+        must stay in the report.
+
+        Real-world case: receipts went to an input location, the goods were
+        moved on to the main stock with internal transfers (zero-valued in
+        Odoo 19), then the input location was archived. Without the archived
+        locations in the set, the receipt is skipped and only the transfer is
+        counted as an entry: right quantity, missing value.
+        """
+        product = self.product_1
+        date_in = fields.Datetime.now() - timedelta(days=20)
+        receipt_type = self.env.ref("stock.picking_type_in")
+        receipt_type.default_location_dest_id = self.location_2
+        receipt = self._create_receipt(product, 10, date_in)
+        receipt_value = sum(receipt.move_ids.mapped("value"))
+        self.assertTrue(receipt_value, "The receipt must be valued")
+        self._create_internal_transfer(
+            product, 10, self.location_2, self.location, date_in
+        )
+        self.location_2.action_archive()
+        self.assertFalse(self.location_2.active)
+
+        # Period covering the receipt: the receipt line itself must be there.
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.date_from = (date_in - timedelta(days=1)).date()
+        wizard.date_to = (date_in + timedelta(days=1)).date()
+        wizard.product_ids.add(product)
+        wizard = wizard.save()
+        self.assertIn(self.location_2, wizard._get_report_locations())
+        wizard.do_compute_product()
+        lines = self.env["l10n.ro.stock.storage.sheet.line"].search(
+            [("report_id", "=", wizard.id), ("product_id", "=", product.id)]
+        )
+        self.assertIn(receipt.name, lines.mapped("reference"))
+
+        # Period after the receipt: the opening balance must carry its value.
+        wizard = Form(self.env["l10n.ro.stock.storage.sheet"])
+        wizard.date_from = (date_in + timedelta(days=5)).date()
+        wizard.date_to = (date_in + timedelta(days=6)).date()
+        wizard.product_ids.add(product)
+        wizard = wizard.save()
+        wizard.do_compute_product()
+        initial = self.env["l10n.ro.stock.storage.sheet.line"].search(
+            [
+                ("report_id", "=", wizard.id),
+                ("product_id", "=", product.id),
+                ("reference", "=", "INITIAL"),
+            ]
+        )
+        self.assertAlmostEqual(sum(initial.mapped("quantity_initial")), 10.0, places=2)
+        self.assertAlmostEqual(
+            sum(initial.mapped("amount_initial")), receipt_value, places=2
+        )


### PR DESCRIPTION
Fixes #1586

Depends on #1587 (stacked on it: shares the internal-transfer test helper; the diff will shrink to one commit once #1587 is merged).

When no location is selected, `location_ids` holds every internal location, so an internal → internal move matched both the input query (`location_dest_id in %(locations)s`) and the output query (`location_id in %(locations)s`). Transfers with `value = 0` only affected quantities, but transfers that carry a value (for example the relocation flows) inflated both Input Amount and Output Amount by the same figure. Measured on a production database for one month: 57 moves, 218,277 RON added to both columns on account 371. Balances were not affected, the turnover was.

Changes:
- input query excludes moves whose source is also in the set, output query excludes moves whose destination is also in the set — a move inside the set is neither an entry nor an exit for it;
- with `detailed_locations` the set is a single location, so a transfer between two locations still shows as an exit from one and an entry into the other (covered by the test);
- test: receipt of 10 plus internal transfer of 4 between two internal locations; whole-stock sheet shows in 10 / out 0 / final 10, per-location sheets show 10 in and 4 out on the source and 4 in on the destination. The whole-stock assertion fails on the previous code (14 instead of 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
