### PR TITLE
[IMP] l10n_ro_pos: install itself, and cover the session that is not …

### DIFF
--- a/l10n_ro_pos/__manifest__.py
+++ b/l10n_ro_pos/__manifest__.py
@@ -10,6 +10,13 @@
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "depends": ["point_of_sale", "l10n_ro_config"],
+    # Any Romanian company with a point of sale needs this. Without it the
+    # session closing entry books the cost of what was sold a second time -
+    # the Romanian stock accounting has already posted that discharge on each
+    # stock move - and the stock account drifts by the value of everything the
+    # shop sold. It has nothing to configure and nothing to choose, so it is
+    # installed wherever both its dependencies are.
+    "auto_install": True,
     "maintainers": ["dhongu", "cristianPanaite"],
     "data": [
         "views/report_saledetails.xml",

--- a/l10n_ro_pos/tests/test_pos.py
+++ b/l10n_ro_pos/tests/test_pos.py
@@ -115,6 +115,73 @@ class TestReportPoSOrder(CommonPosTest):
             "Referința facturii trebuie să fie aceeași cu referința comenzii POS",
         )
 
+    def test_closing_an_uninvoiced_session_carries_no_stock(self):
+        """Close a session on an order that was not invoiced.
+
+        This is the path that can break, and the only one: point of sale
+        leaves invoiced orders out of the stock buckets to begin with
+        (``not p.is_invoiced``), so a check run on an invoiced order never
+        reaches it. On an ordinary till sale the buckets are full, and without
+        the emptying above the closing entry books the cost of the goods a
+        second time - the Romanian stock accounting has already posted that
+        discharge on the stock move - or, worse, carries a valuation line
+        whose counterpart was cleared and comes out unbalanced.
+        """
+        self.pos_config_usd.open_ui()
+        session = self.pos_config_usd.current_session_id
+        order_data = {
+            "amount_paid": 100.0,
+            "amount_return": 0,
+            "amount_tax": 0,
+            "amount_total": 100.0,
+            "date_order": "2024-01-01 10:00:00",
+            "name": "Order 0002",
+            "partner_id": self.ro_partner.id,
+            "session_id": session.id,
+            "lines": [
+                Command.create(
+                    {
+                        "product_id": self.product_a.id,
+                        "price_unit": 100.0,
+                        "qty": 1,
+                        "price_subtotal": 100.0,
+                        "price_subtotal_incl": 100.0,
+                    }
+                )
+            ],
+            "payment_ids": [
+                Command.create(
+                    {
+                        "amount": 100.0,
+                        "payment_method_id": self.cash_payment_method.id,
+                    }
+                )
+            ],
+            "uuid": "0002",
+            "to_invoice": False,
+        }
+        self.env["pos.order"].sync_from_ui([order_data])
+
+        session.action_pos_session_closing_control()
+        self.assertEqual(session.state, "closed")
+
+        closing_accounts = session.move_id.line_ids.account_id
+        accounts = self.product_a.product_tmpl_id.get_product_accounts()
+        for key in ("stock_valuation", "stock_output", "expense"):
+            account = accounts.get(key)
+            if account:
+                self.assertNotIn(
+                    account,
+                    closing_accounts,
+                    f"Nota de inchidere contine o linie de {key}",
+                )
+        self.assertAlmostEqual(
+            sum(session.move_id.line_ids.mapped("debit")),
+            sum(session.move_id.line_ids.mapped("credit")),
+            places=2,
+            msg="Nota de inchidere nu este echilibrata",
+        )
+
     def test_sale_details_stock_columns(self):
         """Raportul Sale Details injecteaza cost unitar / valoare de stoc per produs."""
         report = self.env["report.point_of_sale.report_saledetails"]


### PR DESCRIPTION
…invoiced

The module keeps the session closing entry from booking the cost of what was sold a second time - the Romanian stock accounting has already posted that discharge on each stock move, because every Romanian record creates its own entry. A company that does not have this installed has its stock account drift by the value of everything the shop sells, silently, and there is nothing here to configure or to choose. It now installs wherever point of sale and the Romanian configuration both are.

That is a change for existing databases: on the next module list update it installs itself on any Romanian company running a point of sale, which is the point.

The existing check runs on an invoiced order, and point of sale leaves invoiced orders out of the stock buckets to begin with, so it never reaches the path that can break. The new one closes a session on an ordinary till sale and looks at the entry that comes out: no line on the accounts the product resolves for stock, and debit equal to credit - a valuation line left without the counterpart this module clears is how it last went wrong.