### PR TITLE
[FIX] l10n_ro_fiscal_validation: make the cron test actually test the cron

### DIFF
--- a/l10n_ro_fiscal_validation/tests/test_partner_update_vat_subjected.py
+++ b/l10n_ro_fiscal_validation/tests/test_partner_update_vat_subjected.py
@@ -3,14 +3,17 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import codecs
+import copy
 import csv
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import requests
 
 from odoo.tests.common import TransactionCase
 from odoo.tools import mute_logger
+
+from odoo.addons.l10n_ro_partner_create_by_vat.tests.anaf_data import ANAF_TEST_DATA
 
 
 class TestPartnerUpdateVatSubjectedBase(TransactionCase):
@@ -36,27 +39,46 @@ class TestPartnerUpdateVatSubjectedBase(TransactionCase):
 
         lines = [line for line in csvdata if any(line)]
         cls.env.user.company_id.write({"vat_check_vies": False})
-        for line in lines:
-            cls.partner_model.with_context(**context).create(
+        # A single create() for the whole file: the cron is checked against
+        # more than one ANAF chunk, so this builds over a thousand partners.
+        cls.partners = cls.partner_model.with_context(**context).create(
+            [
                 {
-                    "id": line["id"],
                     "name": line["name"],
                     "vat": line["vat"],
                     "is_company": line["is_company"],
                     "country_id": cls.env.ref("base.ro").id,
                 }
-            )
+                for line in lines
+            ]
+        )
 
 
 class TestUpdatePartner(TestPartnerUpdateVatSubjectedBase):
     def test_vat_subjected_cron(self):
-        """Check methods vat from ANAF."""
+        """The cron asks ANAF about every Romanian company and writes back."""
+        # The company the fake ANAF will answer about.
+        partner = self.partners[0]
+        cui = int(partner.l10n_ro_vat_number)
+        answer = copy.deepcopy(ANAF_TEST_DATA["4264242"])
+        answer["date_generale"]["cui"] = cui
+        answer["date_generale"]["denumire"] = "PARTENER VERIFICAT ANAF SRL"
+        answer["inregistrare_scop_Tva"]["scpTVA"] = True
+
+        calls = []
+
+        class FakeResponse:
+            """Answers without a correlationId, so the cron stays on the direct
+            path: no polling sleep and no follow-up request."""
+
+            status_code = 200
+
+            def json(self):
+                return {"found": [answer], "notFound": []}
 
         def post(url, **kwargs):
-            response = Mock()
-            response.status_code = 200
-            response._content = b"ok"
-            return response
+            calls.append(kwargs.get("json"))
+            return FakeResponse()
 
         with mute_logger("odoo.addons.l10n_ro_fiscal_validation.models.res_partner"):
             with (
@@ -64,3 +86,12 @@ class TestUpdatePartner(TestPartnerUpdateVatSubjectedBase):
                 patch.object(requests.Session, "post", post),
             ):
                 self.partner_model._update_l10n_ro_vat_subjected_all()
+
+        self.assertTrue(calls, "the cron must call ANAF")
+        self.assertGreater(
+            len(calls), 1, "more than a thousand partners must be sent in chunks"
+        )
+        asked = {item["cui"] for chunk in calls for item in chunk}
+        self.assertIn(cui, asked, "the partner must be part of what is asked of ANAF")
+        self.assertEqual(partner.name, "PARTENER VERIFICAT ANAF SRL")
+        self.assertTrue(partner.l10n_ro_vat_subjected)


### PR DESCRIPTION
The fake ANAF answer was a bare ``Mock``, so ``res.json()`` returned another ``Mock``, ``result.get("correlationId")`` was truthy, and the cron took the polling branch: ``time.sleep(3)`` per chunk plus a ``requests.get`` that was never patched and went out to ANAF for real.  Iterating ``result.get("found")`` on the ``Mock`` then raised, and the exception was swallowed by the ``except`` around the whole chunk - so the test asserted nothing and spent its time sleeping and waiting on the network.

Answer with a real payload built from the ``l10n_ro_partner_create_by_vat`` fixture instead, and assert that the partner is both asked about and written back.  Also create the thousand-odd partners of the fixture in one ``create()`` instead of one call each.