### PR TITLE
[FIX] l10n_ro_message_spv: paginated SPV listing no longer fails silently

### DIFF
--- a/l10n_ro_message_spv/README.rst
+++ b/l10n_ro_message_spv/README.rst
@@ -223,6 +223,40 @@ Configuration
 Changelog
 =========
 
+**19.0.2.14.0 (2026-09-10)**
+
+- The paginated SPV message listing no longer fails silently. A page
+  that cannot be read — transport error, unparsable body (an ANAF
+  maintenance page), an HTTP 200 carrying a business error, or a ``401``
+  — now stops the walk and is logged as an error, stating how many
+  messages the partial result holds. Until now any of those left the
+  total page count at zero and returned an empty or partial list without
+  a single log line, so an import stopped by an ANAF error looked
+  exactly like "no messages" and the cron reported success. ANAF's "no
+  messages in the selected interval" note, which arrives in the same
+  ``eroare`` key, is recognised and logged as information rather than as
+  a failure. The import also logs a per-company summary of how many
+  messages were received and how many records were created.
+- Pages are now walked in a loop instead of recursively, with a guard at
+  200 pages (100 000 messages), so an absurd ``numar_total_pagini`` can
+  no longer drive the walk into the recursion limit.
+- The requested time window is pulled inside ANAF's limits. ANAF rejects
+  the whole interval when ``startTime`` is older than 60 days relative
+  to its own clock, and the window was computed by subtracting the
+  requested days from a moment already pushed 60 seconds into the past —
+  so the default 60-day window sat just outside the limit.
+- ``l10n_ro_download_message_spv`` accepts ``no_days``. Without it, a
+  cron that wants a window other than the one configured on the company
+  had to call the private ``_l10n_ro_download_message_spv`` on the bare
+  model; that method iterates ``self``, so on an empty recordset it did
+  nothing at all — no error, no log, and the cron still reported
+  success.
+- Messages whose download failed are no longer retried once they fall
+  outside ANAF's 60-day retention. Their archive no longer exists, so
+  the daily ``error`` to ``draft`` reset kept them in the queue forever,
+  burning API calls and filling the log. A message with no date is still
+  treated as recoverable.
+
 **19.0.2.11.0 (2026-08-19)**
 
 - The partner lookup by tax ID now accepts both spellings of the

--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "19.0.2.13.0",
+    "version": "19.0.2.14.0",
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/ciusro_document.py
+++ b/l10n_ro_message_spv/models/ciusro_document.py
@@ -15,6 +15,25 @@ from odoo.addons.l10n_ro_edi.models.utils import NS_HEADER
 
 _logger = logging.getLogger(__name__)
 
+# Fereastra maxima pe care ANAF o serveste pe endpointurile de lista de mesaje:
+# mesajele sunt pastrate 60 de zile, iar `startTime` nu poate fi mai vechi de atat
+# fata de momentul requestului.
+SPV_MESSAGES_RETENTION_DAYS = 60
+
+# Marje fata de capetele ferestrei. Ambele capete sunt judecate pe ceasul ANAF, iar
+# o secunda de dezacord respinge tot intervalul, deci nu cerem niciodata fereastra
+# exact pe limita.
+SPV_WINDOW_START_MARGIN = timedelta(minutes=5)
+SPV_WINDOW_END_MARGIN = timedelta(seconds=60)
+
+# ANAF serveste maximum 500 de mesaje pe pagina. Garda ne apara de o bucla lunga
+# daca `numar_total_pagini` vine absurd: 200 de pagini = 100.000 de mesaje, mult
+# peste orice volum real pe 60 de zile.
+SPV_MAX_PAGES = 200
+
+# Note pe care ANAF le trimite in cheia `eroare` desi nu sunt erori.
+SPV_NO_RESULTS_HINTS = ("nu exista mesaje",)
+
 
 def make_efactura_request(
     session, company, endpoint, params, data=None
@@ -144,70 +163,162 @@ class L10nRoEdiDocument(models.Model):
         return result
 
     @api.model
+    def _request_ciusro_window_spv(self, no_days=60, start=None, end=None):
+        """Intervalul cerut ANAF, retras inauntrul limitelor pe care le impune.
+
+        :return: tuple ``(then, now)`` de ``datetime``
+        """
+        if not start:
+            now = end and parser.parse(end) or datetime.now() - SPV_WINDOW_END_MARGIN
+            then = now - relativedelta(days=no_days)
+        else:
+            then = parser.parse(start)
+            now = end and parser.parse(end) or (then + relativedelta(days=no_days))
+            now = min(now, datetime.now() - SPV_WINDOW_END_MARGIN)
+
+        # ANAF respinge tot intervalul daca `startTime` e mai vechi de 60 de zile
+        # fata de momentul requestului, judecat pe ceasul lor. O fereastra cerută
+        # exact pe limita — cazul `no_days=60`, adica implicitul de pe companie —
+        # sta pe granita si poate cadea din cauza diferentei de ceas, iar raspunsul
+        # de eroare e greu de distins de „nu sunt mesaje". Retragem startul cu o
+        # marja inauntrul limitei.
+        oldest = (
+            datetime.now()
+            - relativedelta(days=SPV_MESSAGES_RETENTION_DAYS)
+            + SPV_WINDOW_START_MARGIN
+        )
+        if then < oldest:
+            _logger.info(
+                "SPV: startul cerut (%s) e in afara ferestrei de %s zile; "
+                "il retrag la %s.",
+                then,
+                SPV_MESSAGES_RETENTION_DAYS,
+                oldest,
+            )
+            then = oldest
+        return then, now
+
+    @api.model
     def _request_ciusro_download_messages_spv(
         self, company, no_days=60, start=None, end=None, page=1, filtru=""
     ):
+        """Lista mesajelor din SPV pentru `company`, pe toate paginile.
+
+        Foloseste endpointul paginat (`listaMesajePaginatieFactura`), fiindca cel
+        nepaginat refuza cu totul intervalele de peste 500 de mesaje — un volum
+        atins de o singura zi la clientii mari.
+
+        Paginile se parcurg in bucla, nu recursiv, ca sa nu depindem de limita de
+        recursivitate la un numar mare de pagini, si se opresc la `SPV_MAX_PAGES`.
+
+        Orice pagina care nu poate fi citita (eroare de transport, corp neparsabil,
+        eroare de business a ANAF) opreste parcurgerea si e **logata**: paginile
+        deja citite se pastreaza, dar rezultatul e partial. Fara logare, o lista
+        goala din cauza unei erori arata exact ca „nu sunt mesaje" si importul pare
+        ca a rulat cu succes.
+
+        :return: lista mesajelor ANAF ale companiei (posibil partiala la eroare)
+        """
         messages = []
-
-        numar_total_pagini = 0
-        now = then = datetime.now()
-
-        if not start:
-            now = end and parser.parse(end) or datetime.now() - timedelta(seconds=60)
-            then = now - relativedelta(days=no_days)
-        elif start:
-            then = parser.parse(start)
-            now = end and parser.parse(end) or (then + relativedelta(days=no_days))
-            now = min(now, (datetime.now() - timedelta(seconds=60)))
+        then, now = self._request_ciusro_window_spv(
+            no_days=no_days, start=start, end=end
+        )
         start_time = str(then.timestamp() * 1e3).split(".")[0]
         end_time = str(now.timestamp() * 1e3).split(".")[0]
 
         cif = company.vat.replace("RO", "")
-        params = {
-            "cif": cif,
-            "pagina": page,
-            "startTime": start_time,
-            "endTime": end_time,
-        }
-        if filtru:
-            params["filtru"] = filtru
+        current = page
+        last_page = page + SPV_MAX_PAGES - 1
+        while current <= last_page:
+            params = {
+                "cif": cif,
+                "pagina": current,
+                "startTime": start_time,
+                "endTime": end_time,
+            }
+            if filtru:
+                params["filtru"] = filtru
 
-        result = make_efactura_request(
-            session=requests,
-            company=company,
-            endpoint="listaMesajePaginatieFactura",
-            params=params,
-        )
-
-        if "error" not in result:
-            content = result["content"]
-            doc = json.loads(content.decode("utf-8"))
-            if doc.get("status", False) == "401":
-                _logger.error("401 Unauthorized")
-                return False
-            company_messages = list(
-                filter(
-                    lambda m: m.get("cif") == cif,
-                    doc.get("mesaje") or [],
-                )
-            )
-            others_messages = list(
-                filter(
-                    lambda m: m.get("cif") != cif,
-                    doc.get("mesaje") or [],
-                )
-            )
-            _logger.info(f"Other messages: {others_messages}")
-            messages += company_messages
-            numar_total_pagini = doc.get("numar_total_pagini", 0)
-
-        if page < numar_total_pagini:
-            messages += self._request_ciusro_download_messages_spv(
+            result = make_efactura_request(
+                session=requests,
                 company=company,
-                no_days=no_days,
-                start=start,
-                end=end,
-                page=page + 1,
-                filtru=filtru,
+                endpoint="listaMesajePaginatieFactura",
+                params=params,
             )
+            if "error" in result:
+                _logger.error(
+                    "SPV: pagina %s pentru CIF %s a esuat (%s). "
+                    "Rezultat partial: %s mesaje.",
+                    current,
+                    cif,
+                    result["error"],
+                    len(messages),
+                )
+                break
+
+            try:
+                doc = json.loads(result["content"].decode("utf-8"))
+            except ValueError:
+                _logger.error(
+                    "SPV: raspuns neparsabil pe pagina %s pentru CIF %s. "
+                    "Rezultat partial: %s mesaje.",
+                    current,
+                    cif,
+                    len(messages),
+                )
+                break
+
+            if str(doc.get("status") or "") == "401":
+                _logger.error(
+                    "SPV: 401 Unauthorized pe pagina %s pentru CIF %s. "
+                    "Rezultat partial: %s mesaje.",
+                    current,
+                    cif,
+                    len(messages),
+                )
+                break
+
+            # ANAF trimite pe HTTP 200, in aceeasi cheie `eroare`, atat erorile
+            # reale cat si nota „nu exista mesaje in intervalul selectat".
+            eroare = doc.get("eroare")
+            if eroare:
+                if any(hint in eroare.lower() for hint in SPV_NO_RESULTS_HINTS):
+                    _logger.info("SPV: %s (CIF %s).", eroare, cif)
+                else:
+                    _logger.error(
+                        "SPV: eroare pe pagina %s pentru CIF %s: %s. "
+                        "Rezultat partial: %s mesaje.",
+                        current,
+                        cif,
+                        eroare,
+                        len(messages),
+                    )
+                break
+
+            page_messages = doc.get("mesaje") or []
+            company_messages = [m for m in page_messages if m.get("cif") == cif]
+            others = len(page_messages) - len(company_messages)
+            if others:
+                # Mesajele altor CIF-uri nu ne privesc; le numaram, nu le varsam
+                # in log — la 500 de mesaje pe pagina ar inunda jurnalul.
+                _logger.debug(
+                    "SPV: pagina %s conține %s mesaje ale altor CIF-uri.",
+                    current,
+                    others,
+                )
+            messages += company_messages
+
+            numar_total_pagini = doc.get("numar_total_pagini") or 0
+            if current >= numar_total_pagini:
+                break
+            current += 1
+        else:
+            _logger.error(
+                "SPV: garda de %s pagini atinsa pentru CIF %s; "
+                "rezultat trunchiat la %s mesaje.",
+                SPV_MAX_PAGES,
+                cif,
+                len(messages),
+            )
+
         return messages

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -9,6 +9,8 @@ import pytz
 
 from odoo import fields, models
 
+from .ciusro_document import SPV_MESSAGES_RETENTION_DAYS
+
 _logger = logging.getLogger(__name__)
 
 
@@ -31,17 +33,42 @@ class ResCompany(models.Model):
         for company in ro_companies:
             # Resetăm la draft mesajele căzute în eroare în zilele trecute, ca să
             # fie reîncercate (cota ANAF de 10 descărcări/zi/mesaj se reînnoiește).
-            error_messages_from_past = company.env["l10n.ro.message.spv"].search(
-                [
-                    ("company_id", "=", company.id),
-                    ("attachment_id", "=", False),
-                    ("state", "=", "error"),
-                    ("last_download_date", "<", fields.Date.today()),
-                ]
+            # Excepție: ANAF servește arhivele doar 60 de zile, deci un mesaj mai
+            # vechi de atât nu mai poate fi descărcat niciodată. Resetat, ar intra
+            # într-o reîncercare zilnică perpetuă — consumă apeluri, umple
+            # jurnalul și ține coada plină cu mesaje fără nicio șansă de reușită.
+            oldest_downloadable = fields.Datetime.subtract(
+                fields.Datetime.now(), days=SPV_MESSAGES_RETENTION_DAYS
             )
+            spv_messages = company.env["l10n.ro.message.spv"]
+            error_domain = [
+                ("company_id", "=", company.id),
+                ("attachment_id", "=", False),
+                ("state", "=", "error"),
+                ("last_download_date", "<", fields.Date.today()),
+            ]
+            # `date` necompletat (mesaj creat manual sau import vechi) nu e o
+            # dovada ca arhiva a expirat, deci ramane reincercabil.
+            recoverable = [
+                "|",
+                ("date", "=", False),
+                ("date", ">=", oldest_downloadable),
+            ]
+            error_messages_from_past = spv_messages.search(error_domain + recoverable)
             if error_messages_from_past:
                 error_messages_from_past.write(
                     {"state": "draft", "download_attempts": 0}
+                )
+            expired = spv_messages.search_count(
+                error_domain
+                + [("date", "!=", False), ("date", "<", oldest_downloadable)]
+            )
+            if expired:
+                _logger.info(
+                    "SPV: %s mesaj(e) in eroare mai vechi de %s zile nu se mai "
+                    "reincearca — arhiva nu mai exista la ANAF.",
+                    expired,
+                    SPV_MESSAGES_RETENTION_DAYS,
                 )
 
             # Procesăm mesajele în starea draft (state="error" rămâne exclus,
@@ -86,11 +113,18 @@ class ResCompany(models.Model):
                 "l10n_ro_message_spv.ir_cron_download_zip_message_spv"
             )._trigger()
 
-    def l10n_ro_download_message_spv(self):
-        # method to be used in cron job to auto download e-invoices from ANAF
+    def l10n_ro_download_message_spv(self, no_days=0):
+        """Punctul de intrare public pentru importul mesajelor din SPV.
+
+        `no_days` e expus aici, nu doar pe metoda privata, fiindca altfel un cron
+        care vrea alta fereastra decat cea de pe companie e nevoit sa cheme metoda
+        privata. Aceea itereaza `self`, deci apelata pe modelul gol din codul unui
+        cron (`model._l10n_ro_download_message_spv(...)`) nu face nimic, fara
+        eroare si fara log — un import oprit tacit, cu cronul raportand succes.
+        """
         domain = [("l10n_ro_edi_access_token", "!=", False)]
         ro_companies = self or self.env["res.company"].sudo().search(domain)
-        return ro_companies._l10n_ro_download_message_spv()
+        return ro_companies._l10n_ro_download_message_spv(no_days=no_days)
 
     def _l10n_ro_get_partner_from_cif(self, cif):
         self.ensure_one()
@@ -156,9 +190,11 @@ class ResCompany(models.Model):
             )
             message_spv_obj = obj_message_spv.with_company(company).sudo()
 
+            created = 0
             for message in company_messages:
                 domain = [("name", "=", message["id"])]
                 if not message_spv_obj.search(domain, limit=1):
+                    created += 1
                     date = datetime.strptime(message.get("data_creare"), "%Y%m%d%H%M")
                     localized_date = romania_tz.localize(date)
                     # Convertim data și ora la GMT
@@ -200,5 +236,16 @@ class ResCompany(models.Model):
                             "state": "draft",
                         }
                     )
+
+            # Sumar per companie: fara el, un import care n-a adus nimic nu se
+            # deosebeste in jurnal de unul care n-a rulat deloc.
+            _logger.info(
+                "SPV: %s: %s mesaj(e) primite pe fereastra de %s zile, "
+                "%s inregistrare(i) noua(e).",
+                company.name,
+                len(company_messages),
+                days,
+                created,
+            )
 
         return True

--- a/l10n_ro_message_spv/readme/HISTORY.md
+++ b/l10n_ro_message_spv/readme/HISTORY.md
@@ -1,3 +1,36 @@
+**19.0.2.14.0 (2026-09-10)**
+
+- The paginated SPV message listing no longer fails silently. A page that
+  cannot be read — transport error, unparsable body (an ANAF maintenance
+  page), an HTTP 200 carrying a business error, or a `401` — now stops the
+  walk and is logged as an error, stating how many messages the partial
+  result holds. Until now any of those left the total page count at zero
+  and returned an empty or partial list without a single log line, so an
+  import stopped by an ANAF error looked exactly like "no messages" and
+  the cron reported success. ANAF's "no messages in the selected
+  interval" note, which arrives in the same `eroare` key, is recognised
+  and logged as information rather than as a failure. The import also
+  logs a per-company summary of how many messages were received and how
+  many records were created.
+- Pages are now walked in a loop instead of recursively, with a guard at
+  200 pages (100 000 messages), so an absurd `numar_total_pagini` can no
+  longer drive the walk into the recursion limit.
+- The requested time window is pulled inside ANAF's limits. ANAF rejects
+  the whole interval when `startTime` is older than 60 days relative to
+  its own clock, and the window was computed by subtracting the requested
+  days from a moment already pushed 60 seconds into the past — so the
+  default 60-day window sat just outside the limit.
+- `l10n_ro_download_message_spv` accepts `no_days`. Without it, a cron
+  that wants a window other than the one configured on the company had to
+  call the private `_l10n_ro_download_message_spv` on the bare model;
+  that method iterates `self`, so on an empty recordset it did nothing at
+  all — no error, no log, and the cron still reported success.
+- Messages whose download failed are no longer retried once they fall
+  outside ANAF's 60-day retention. Their archive no longer exists, so the
+  daily `error` to `draft` reset kept them in the queue forever, burning
+  API calls and filling the log. A message with no date is still treated
+  as recoverable.
+
 **19.0.2.11.0 (2026-08-19)**
 
 - The partner lookup by tax ID now accepts both spellings of the Romanian

--- a/l10n_ro_message_spv/static/description/index.html
+++ b/l10n_ro_message_spv/static/description/index.html
@@ -599,6 +599,40 @@ XML-ul a fost validat de sistemul ANAF.</li>
 </div>
 <div class="section" id="changelog">
 <h4><a class="toc-backref" href="#toc-entry-2">Changelog</a></h4>
+<p><strong>19.0.2.14.0 (2026-09-10)</strong></p>
+<ul class="simple">
+<li>The paginated SPV message listing no longer fails silently. A page
+that cannot be read — transport error, unparsable body (an ANAF
+maintenance page), an HTTP 200 carrying a business error, or a <tt class="docutils literal">401</tt>
+— now stops the walk and is logged as an error, stating how many
+messages the partial result holds. Until now any of those left the
+total page count at zero and returned an empty or partial list without
+a single log line, so an import stopped by an ANAF error looked
+exactly like “no messages” and the cron reported success. ANAF’s “no
+messages in the selected interval” note, which arrives in the same
+<tt class="docutils literal">eroare</tt> key, is recognised and logged as information rather than as
+a failure. The import also logs a per-company summary of how many
+messages were received and how many records were created.</li>
+<li>Pages are now walked in a loop instead of recursively, with a guard at
+200 pages (100 000 messages), so an absurd <tt class="docutils literal">numar_total_pagini</tt> can
+no longer drive the walk into the recursion limit.</li>
+<li>The requested time window is pulled inside ANAF’s limits. ANAF rejects
+the whole interval when <tt class="docutils literal">startTime</tt> is older than 60 days relative
+to its own clock, and the window was computed by subtracting the
+requested days from a moment already pushed 60 seconds into the past —
+so the default 60-day window sat just outside the limit.</li>
+<li><tt class="docutils literal">l10n_ro_download_message_spv</tt> accepts <tt class="docutils literal">no_days</tt>. Without it, a
+cron that wants a window other than the one configured on the company
+had to call the private <tt class="docutils literal">_l10n_ro_download_message_spv</tt> on the bare
+model; that method iterates <tt class="docutils literal">self</tt>, so on an empty recordset it did
+nothing at all — no error, no log, and the cron still reported
+success.</li>
+<li>Messages whose download failed are no longer retried once they fall
+outside ANAF’s 60-day retention. Their archive no longer exists, so
+the daily <tt class="docutils literal">error</tt> to <tt class="docutils literal">draft</tt> reset kept them in the queue forever,
+burning API calls and filling the log. A message with no date is still
+treated as recoverable.</li>
+</ul>
 <p><strong>19.0.2.11.0 (2026-08-19)</strong></p>
 <ul class="simple">
 <li>The partner lookup by tax ID now accepts both spellings of the

--- a/l10n_ro_message_spv/tests/__init__.py
+++ b/l10n_ro_message_spv/tests/__init__.py
@@ -3,3 +3,4 @@ from . import common
 
 from . import test_message_spv
 from . import test_controller
+from . import test_spv_pagination

--- a/l10n_ro_message_spv/tests/test_spv_pagination.py
+++ b/l10n_ro_message_spv/tests/test_spv_pagination.py
@@ -1,0 +1,241 @@
+# Copyright (C) 2026 Terrabit
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import json
+from datetime import datetime
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields
+from odoo.tests import tagged
+
+from odoo.addons.l10n_ro_message_spv.models.ciusro_document import (
+    SPV_MAX_PAGES,
+    SPV_MESSAGES_RETENTION_DAYS,
+)
+
+from .common import TestMessageSPV
+
+CIF = "30834857"
+LOGGER = "odoo.addons.l10n_ro_message_spv.models.ciusro_document"
+
+
+def _message(index):
+    """Un mesaj ANAF minimal, dar cu toate cheile pe care le citeste importul."""
+    return {
+        "data_creare": "202609010940",
+        "cif": CIF,
+        "id_solicitare": f"500000{index}",
+        "detalii": (
+            f"Factura cu id_incarcare=500000{index} emisa de cif_emitent=8486152 "
+            f"pentru cif_beneficiar={CIF}"
+        ),
+        "tip": "FACTURA PRIMITA",
+        "id": f"300000{index}",
+    }
+
+
+def _page(messages, numar_total_pagini):
+    payload = {
+        "mesaje": messages,
+        "serial": "1234AA456",
+        "cui": CIF,
+        "titlu": "Lista Mesaje disponibile",
+        "numar_total_pagini": numar_total_pagini,
+    }
+    return {"content": json.dumps(payload).encode("utf-8")}
+
+
+@tagged("post_install", "-at_install")
+class TestSpvPagination(TestMessageSPV):
+    """Paginarea listei de mesaje din SPV.
+
+    ANAF refuza cu totul intervalele de peste 500 de mesaje pe endpointul
+    nepaginat, iar la clientii mari o singura zi depaseste pragul, deci importul
+    depinde de parcurgerea corecta a paginilor si de raportarea eșecurilor.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.document = cls.env["l10n_ro_edi.document"]
+
+    def _fetch(self, responses, **kwargs):
+        """Ruleaza importul cu `responses` servite pe rand, si intoarce
+        (mesaje, parametrii fiecarui apel)."""
+        calls = []
+
+        def fake_request(session, company, endpoint, params, data=None):
+            calls.append(params)
+            return responses[min(len(calls) - 1, len(responses) - 1)]
+
+        with patch(f"{LOGGER}.make_efactura_request", side_effect=fake_request):
+            messages = self.document._request_ciusro_download_messages_spv(
+                self.env.company, **kwargs
+            )
+        return messages, calls
+
+    def test_walks_every_page(self):
+        """Toate paginile sunt parcurse, iar mesajele se acumuleaza in ordine."""
+        responses = [
+            _page([_message(1), _message(2)], 3),
+            _page([_message(3)], 3),
+            _page([_message(4)], 3),
+        ]
+        messages, calls = self._fetch(responses)
+
+        self.assertEqual(
+            [m["id"] for m in messages], ["3000001", "3000002", "3000003", "3000004"]
+        )
+        self.assertEqual([p["pagina"] for p in calls], [1, 2, 3])
+
+    def test_single_page_does_not_ask_for_a_second(self):
+        """O singura pagina nu declanseaza un apel in plus."""
+        messages, calls = self._fetch([_page([_message(1)], 1)])
+
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(len(calls), 1)
+
+    def test_error_on_middle_page_keeps_pages_already_read(self):
+        """Eroarea pe o pagina din mijloc nu pierde paginile citite, dar e logata.
+
+        Fara logare, rezultatul partial ar fi indistingibil de un import complet.
+        """
+        responses = [
+            _page([_message(1)], 3),
+            {"error": "Timeout while sending to SPV."},
+        ]
+
+        with self.assertLogs(LOGGER, level="ERROR") as logs:
+            messages, calls = self._fetch(responses)
+
+        self.assertEqual([m["id"] for m in messages], ["3000001"])
+        self.assertEqual([p["pagina"] for p in calls], [1, 2])
+        self.assertIn("Rezultat partial: 1 mesaje", "\n".join(logs.output))
+
+    def test_business_error_is_logged_and_stops(self):
+        """O eroare de business a ANAF (HTTP 200 cu `eroare`) e logata ca eroare."""
+        payload = {"eroare": "Nu aveti drept in SPV pentru CIF=30834857"}
+        response = {"content": json.dumps(payload).encode("utf-8")}
+
+        with self.assertLogs(LOGGER, level="ERROR") as logs:
+            messages, calls = self._fetch([response])
+
+        self.assertEqual(messages, [])
+        self.assertEqual(len(calls), 1)
+        self.assertIn("Nu aveti drept in SPV", "\n".join(logs.output))
+
+    def test_no_results_note_is_not_an_error(self):
+        """„Nu exista mesaje" vine tot pe cheia `eroare`, dar nu e o eroare."""
+        payload = {"eroare": "Nu exista mesaje in intervalul selectat"}
+        response = {"content": json.dumps(payload).encode("utf-8")}
+
+        with self.assertLogs(LOGGER, level="INFO") as logs:
+            messages, _calls = self._fetch([response])
+
+        self.assertEqual(messages, [])
+        self.assertFalse([line for line in logs.output if line.startswith("ERROR")])
+
+    def test_unparsable_body_is_logged_and_stops(self):
+        """Un corp neparsabil (pagina HTML de mentenanta) nu ridica excepție."""
+        with self.assertLogs(LOGGER, level="ERROR") as logs:
+            messages, calls = self._fetch([{"content": b"<html>mentenanta</html>"}])
+
+        self.assertEqual(messages, [])
+        self.assertEqual(len(calls), 1)
+        self.assertIn("neparsabil", "\n".join(logs.output))
+
+    def test_absurd_total_pages_is_capped(self):
+        """Un `numar_total_pagini` absurd nu ne trimite intr-o bucla lunga."""
+        with self.assertLogs(LOGGER, level="ERROR") as logs:
+            messages, calls = self._fetch([_page([_message(1)], 10**6)])
+
+        self.assertEqual(len(calls), SPV_MAX_PAGES)
+        self.assertEqual(len(messages), SPV_MAX_PAGES)
+        self.assertIn("garda de", "\n".join(logs.output))
+
+    def test_messages_of_other_cifs_are_dropped(self):
+        """Mesajele altor CIF-uri nu intra in lista companiei."""
+        other = dict(_message(9), cif="99999999")
+        messages, _calls = self._fetch([_page([_message(1), other], 1)])
+
+        self.assertEqual([m["id"] for m in messages], ["3000001"])
+
+    def test_window_start_is_pulled_inside_the_retention_limit(self):
+        """Fereastra de 60 de zile — implicitul de pe companie — nu se cere pe limita.
+
+        ANAF respinge intervalul daca `startTime` e mai vechi de 60 de zile fata de
+        momentul requestului, iar codul scadea zilele dintr-un `now` deja retras cu
+        60 de secunde, deci cadea mereu cu o secunda in afara.
+        """
+        _messages, calls = self._fetch(
+            [_page([], 1)], no_days=SPV_MESSAGES_RETENTION_DAYS
+        )
+
+        start = datetime.fromtimestamp(int(calls[0]["startTime"]) / 1000)
+        limit = datetime.now() - relativedelta(days=SPV_MESSAGES_RETENTION_DAYS)
+        self.assertGreater(start, limit)
+
+
+@tagged("post_install", "-at_install")
+class TestSpvCronEntryPoints(TestMessageSPV):
+    """Punctele de intrare folosite din codul cronurilor."""
+
+    def test_public_entry_point_accepts_no_days(self):
+        """Wrapperul public accepta `no_days` si isi rezolva singur companiile.
+
+        Fara parametru, un cron care vrea alta fereastra decat cea de pe companie
+        e nevoit sa cheme metoda privata pe modelul gol (`model._l10n_ro_...`), care
+        itereaza `self` si deci nu face nimic — fara eroare si fara log.
+        """
+        with patch(
+            f"{LOGGER}.make_efactura_request", return_value=_page([_message(1)], 1)
+        ):
+            self.env["res.company"].l10n_ro_download_message_spv(no_days=7)
+
+        message = self.env["l10n.ro.message.spv"].search([("name", "=", "3000001")])
+        self.assertEqual(len(message), 1)
+        self.assertEqual(message.company_id, self.env.company)
+
+    def test_expired_error_messages_are_not_retried(self):
+        """Mesajele in eroare ieșite din fereastra ANAF nu se mai reincearca.
+
+        Arhiva lor nu mai exista, deci resetarea zilnica la draft le-ar tine
+        perpetuu in coada, consumand apeluri fara nicio sansa de reusita.
+        """
+        yesterday = fields.Date.today() - relativedelta(days=1)
+        common = {
+            "company_id": self.env.company.id,
+            "message_type": "in_invoice",
+            "state": "error",
+            "download_attempts": 3,
+            "last_download_date": yesterday,
+        }
+        expired = self.env["l10n.ro.message.spv"].create(
+            dict(
+                common,
+                name="EXPIRAT",
+                date=fields.Datetime.now()
+                - relativedelta(days=SPV_MESSAGES_RETENTION_DAYS + 10),
+            )
+        )
+        recent = self.env["l10n.ro.message.spv"].create(
+            dict(
+                common,
+                name="RECENT",
+                date=fields.Datetime.now() - relativedelta(days=5),
+            )
+        )
+        undated = self.env["l10n.ro.message.spv"].create(dict(common, name="FARA_DATA"))
+
+        # limit=0 ca sa testam doar resetul, fara nicio descarcare efectiva
+        self.env.company.l10n_ro_download_zip_message_spv(limit=0)
+
+        self.assertEqual(expired.state, "error", "un mesaj expirat nu se reincearca")
+        self.assertEqual(expired.download_attempts, 3)
+        self.assertEqual(recent.state, "draft", "un mesaj recent revine in coada")
+        self.assertEqual(recent.download_attempts, 0)
+        self.assertEqual(
+            undated.state, "draft", "lipsa datei nu e dovada ca arhiva a expirat"
+        )


### PR DESCRIPTION
The paginated SPV message listing (`listaMesajePaginatieFactura`) was already in place, but a page that could not be read left `numar_total_pagini` at zero, stopped the recursion and returned a partial — or empty — list **without a single log line**. An import stopped by an ANAF error looked exactly like "no messages", and the cron reported success.

This was found while investigating a production database where SPV message import had been dead for six days with roughly 1400 messages not fetched (79 of them supplier invoices), the cron running daily and reporting `failure_count = 0`.

## Changes

- Pages are walked in a **loop** with a guard at 200 pages (100 000 messages), so an absurd `numar_total_pagini` can no longer reach the recursion limit.
- A transport error, an unparsable body (an ANAF maintenance page), a `401` and a business error carried on HTTP 200 all **stop the walk and are logged**, stating how many messages the partial result holds. ANAF's "no messages in the selected interval" note, which arrives in the same `eroare` key, is recognised and logged as information rather than as a failure.
- The import logs a per-company summary — messages received and records created. Without it, an import that brought nothing back was indistinguishable in the log from one that never ran.
- The requested window is pulled inside ANAF's limits. ANAF rejects the interval when `startTime` is older than 60 days measured against its own clock, and the days were subtracted from a moment already pushed 60 seconds into the past — so the 60-day default configured on the company fell one second outside the limit on every call.
- `l10n_ro_download_message_spv` accepts `no_days`. Without the parameter, a cron wanting a window other than the one configured on the company had to call the private `_l10n_ro_download_message_spv` on the bare model; that method iterates `self`, so on an empty recordset it did nothing at all — no error, no log, and the cron still reported success. This is precisely what killed the import in the case above.
- Messages whose download failed are no longer retried once they fall outside ANAF's 60-day retention. Their archive no longer exists, so the daily `error` to `draft` reset kept them in the queue forever, burning API calls and filling the log. A message with no date is still treated as recoverable.

## Why pagination is mandatory here

The non-paginated endpoint caps at 500 messages and answers on HTTP 200 with `eroare`: *"Lista de mesaje este mai mare decat numarul de 500 elemente permise in pagina. Folositi endpoint-ul cu paginatie."* Volumes measured on a production database with a single company:

| window | messages | pages of 500 |
|---|---|---|
| 1 day | 1368 | 3 |
| 60 days | 15707 | 32 |

24 of 395 days with messages were above the 500 threshold.

## Tests

New `tests/test_spv_pagination.py`, 11 tests: walking every page, not asking for a second page when there is only one, an error on a middle page (keeps the pages already read and logs), a business error, the "no messages" note not treated as an error, an unparsable body, the page guard, dropping messages of other CIFs, the window being pulled inside the 60-day limit, the public entry point with `no_days`, and expired error messages no longer being retried.

The module's full suite is green on this branch (54 tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)